### PR TITLE
TECH-514: Module adjustments

### DIFF
--- a/app/app.tf
+++ b/app/app.tf
@@ -217,7 +217,7 @@ module "ca" {
   vpc       = module.vpc
   cluster   = module.ecs_cluster
   db        = module.ca_db
-  log_group = module.ecs_cluster.log_group
+  log_group = module.ecs_cluster.log_group_name
 
   task_execution_role = aws_iam_role.ecs_tasks_execution_role
   docker_image        = var.ca_image
@@ -246,7 +246,7 @@ module "www" {
   task_security_group_id = aws_security_group.web_security_group.id
 
   db        = module.web_db
-  log_group = module.ecs_cluster.log_group
+  log_group = module.ecs_cluster.log_group_name
 
   erl_cookie             = var.erl_cookie
   live_view_signing_salt = var.www_live_view_signing_salt
@@ -277,7 +277,7 @@ module "api" {
   task_security_group_id = aws_security_group.web_security_group.id
 
   db        = module.web_db
-  log_group = module.ecs_cluster.log_group
+  log_group = module.ecs_cluster.log_group_name
 
   erl_cookie      = var.erl_cookie
   app_bucket      = aws_s3_bucket.web_application_data.bucket
@@ -308,7 +308,7 @@ module "device" {
   task_security_group_id = aws_security_group.web_security_group.id
 
   db        = module.web_db
-  log_group = module.ecs_cluster.log_group
+  log_group = module.ecs_cluster.log_group_name
 
   erl_cookie      = var.erl_cookie
   app_bucket      = aws_s3_bucket.web_application_data.bucket

--- a/app/app.tf
+++ b/app/app.tf
@@ -204,7 +204,7 @@ module "ca_db" {
   engine_version    = var.db_engine_version
   vpc_id            = module.vpc.vpc_id
   kms_key           = aws_kms_key.db_enc_key.arn
-  security_groups   = module.ca.security_group
+  security_groups   = module.ca.security_group_id
 }
 
 module "ca" {

--- a/app/app.tf
+++ b/app/app.tf
@@ -115,24 +115,7 @@ module "web_db" {
   engine_version    = var.db_engine_version
   vpc_id            = module.vpc.vpc_id
   kms_key           = aws_kms_key.db_enc_key.arn
-}
-
-resource "aws_security_group_rule" "db_security_group_web_ingress" {
-  type                     = "ingress"
-  from_port                = 5432
-  to_port                  = 5432
-  protocol                 = "tcp"
-  source_security_group_id = aws_security_group.web_security_group.id
-  security_group_id        = module.web_db.security_group.id
-}
-
-resource "aws_security_group_rule" "db_security_group_web_egress" {
-  type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = module.web_db.security_group.id
+  security_groups   = aws_security_group.web_security_group.id
 }
 
 # Storage
@@ -221,6 +204,7 @@ module "ca_db" {
   engine_version    = var.db_engine_version
   vpc_id            = module.vpc.vpc_id
   kms_key           = aws_kms_key.db_enc_key.arn
+  security_groups   = module.ca.security_group
 }
 
 module "ca" {

--- a/app/ecs.tf
+++ b/app/ecs.tf
@@ -7,5 +7,5 @@ module "ecs_cluster" {
   aws_private_subnet_ids = module.vpc.private_subnets
   aws_public_subnet_ids  = module.vpc.public_subnets
   log_retention          = var.log_retention
-  whitelist              = var.whitelist
+  allow_list             = var.allow_list
 }

--- a/billing/billing.tf
+++ b/billing/billing.tf
@@ -24,7 +24,7 @@ module "billing" {
   vpc        = module.vpc
   cluster    = module.ecs_cluster
   db         = module.billing_db
-  log_group  = module.ecs_cluster.log_group
+  log_group  = module.ecs_cluster.log_group_name
   app_bucket = aws_s3_bucket.web_application_data.bucket
   ca_bucket  = module.ca.bucket
 

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -95,7 +95,7 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_s3_log_bucket_name" {
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_app_name" {
   name      = "/${local.app_name}/${terraform.workspace}/APP_NAME"
   type      = "String"
-  value     = "${local.app_name}"
+  value     = local.app_name
   overwrite = true
 }
 

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -212,7 +212,7 @@ resource "aws_iam_role" "api_task_role" {
   ]
 }
 EOF
-  tags = var.tags
+  tags               = var.tags
 }
 
 data "aws_iam_policy_document" "api_iam_policy" {

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -69,6 +69,7 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_secret_db_url" {
   type      = "SecureString"
   value     = "postgres://${var.db.username}:${var.db.password}@${var.db.endpoint}/${var.db.name}"
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_secret_erl_cookie" {
@@ -76,6 +77,7 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_secret_erl_cookie" {
   type      = "SecureString"
   value     = var.erl_cookie
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_s3_ssl_bucket" {
@@ -83,6 +85,7 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_s3_ssl_bucket" {
   type      = "String"
   value     = var.ca_bucket
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_s3_log_bucket_name" {
@@ -90,6 +93,7 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_s3_log_bucket_name" {
   type      = "String"
   value     = var.log_bucket
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_app_name" {
@@ -97,6 +101,7 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_app_name" {
   type      = "String"
   value     = local.app_name
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_cluster" {
@@ -104,6 +109,7 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_cluster" {
   type      = "String"
   value     = var.cluster.name
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_aws_region" {
@@ -111,6 +117,7 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_aws_region" {
   type      = "String"
   value     = var.region
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_port" {
@@ -118,6 +125,7 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_port" {
   type      = "String"
   value     = 80
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_host" {
@@ -125,6 +133,7 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_host" {
   type      = "String"
   value     = "api.${terraform.workspace}.${var.domain}"
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_ca_host" {
@@ -132,6 +141,7 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_ca_host" {
   type      = "String"
   value     = var.ca_host
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_s3_bucket_name" {
@@ -139,6 +149,7 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_s3_bucket_name" {
   type      = "String"
   value     = var.app_bucket
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_secret_secret_key_base" {
@@ -146,6 +157,7 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_secret_secret_key_base" {
   type      = "SecureString"
   value     = var.secret_key_base
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_ses_port" {
@@ -153,6 +165,7 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_ses_port" {
   type      = "String"
   value     = "587"
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_ses_server" {
@@ -160,6 +173,7 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_ses_server" {
   type      = "String"
   value     = "email-smtp.${var.region}.amazonaws.com"
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_smtp_username" {
@@ -167,6 +181,7 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_smtp_username" {
   type      = "SecureString"
   value     = var.smtp_password
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_secret_smtp_password" {
@@ -174,6 +189,7 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_secret_smtp_password" {
   type      = "SecureString"
   value     = var.smtp_username
   overwrite = true
+  tags      = var.tags
 }
 
 # Roles
@@ -196,7 +212,7 @@ resource "aws_iam_role" "api_task_role" {
   ]
 }
 EOF
-
+  tags = var.tags
 }
 
 data "aws_iam_policy_document" "api_iam_policy" {

--- a/modules/ca/main.tf
+++ b/modules/ca/main.tf
@@ -52,9 +52,8 @@ resource "aws_s3_bucket" "ca_application_data" {
   logging {
     target_bucket = var.s3_access_log_bucket
     target_prefix = var.s3_prefix
-
-    tags = var.tags
   }
+  tags = var.tags
 }
 
 resource "aws_s3_bucket_public_access_block" "ca_application_data" {

--- a/modules/ca/main.tf
+++ b/modules/ca/main.tf
@@ -31,29 +31,10 @@ resource "aws_security_group_rule" "ca_security_group_web_ingress" {
   security_group_id        = aws_security_group.ca_security_group.id
 }
 
-resource "aws_security_group_rule" "db_security_group_ca_ingress" {
-  type                     = "ingress"
-  from_port                = 5432
-  to_port                  = 5432
-  protocol                 = "tcp"
-  source_security_group_id = aws_security_group.ca_security_group.id
-  security_group_id        = var.db.security_group.id
-}
-
-resource "aws_security_group_rule" "db_security_group_ca_egress" {
-  type              = "egress"
-  from_port         = 0
-  to_port           = 0
-  protocol          = "-1"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = var.db.security_group.id
-}
-
-
 # Storage
 resource "aws_s3_bucket" "ca_application_data" {
   bucket = "${var.bucket_prefix}-${terraform.workspace}-ca"
-  acl    = "private"
+  acl = "private"
 
   versioning {
     enabled = false
@@ -63,7 +44,7 @@ resource "aws_s3_bucket" "ca_application_data" {
     rule {
       apply_server_side_encryption_by_default {
         kms_master_key_id = var.kms_key.arn
-        sse_algorithm     = "aws:kms"
+        sse_algorithm = "aws:kms"
       }
     }
   }
@@ -72,7 +53,8 @@ resource "aws_s3_bucket" "ca_application_data" {
     target_bucket = var.s3_access_log_bucket
     target_prefix = var.s3_prefix
 
-  tags = var.tags
+    tags = var.tags
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "ca_application_data" {

--- a/modules/ca/main.tf
+++ b/modules/ca/main.tf
@@ -34,7 +34,7 @@ resource "aws_security_group_rule" "ca_security_group_web_ingress" {
 # Storage
 resource "aws_s3_bucket" "ca_application_data" {
   bucket = "${var.bucket_prefix}-${terraform.workspace}-ca"
-  acl = "private"
+  acl    = "private"
 
   versioning {
     enabled = false
@@ -44,7 +44,7 @@ resource "aws_s3_bucket" "ca_application_data" {
     rule {
       apply_server_side_encryption_by_default {
         kms_master_key_id = var.kms_key.arn
-        sse_algorithm = "aws:kms"
+        sse_algorithm     = "aws:kms"
       }
     }
   }
@@ -149,7 +149,7 @@ resource "aws_iam_role" "ca_task_role" {
   ]
 }
 EOF
-  tags = var.tags
+  tags               = var.tags
 }
 
 data "aws_iam_policy_document" "ca_iam_policy" {

--- a/modules/ca/main.tf
+++ b/modules/ca/main.tf
@@ -94,6 +94,7 @@ resource "aws_ssm_parameter" "nerves_hub_ca_ssm_secret_db_url" {
   type      = "SecureString"
   value     = "postgres://${var.db.username}:${var.db.password}@${var.db.endpoint}/${var.db.name}"
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_ca_ssm_secret_erl_cookie" {
@@ -101,6 +102,7 @@ resource "aws_ssm_parameter" "nerves_hub_ca_ssm_secret_erl_cookie" {
   type      = "SecureString"
   value     = var.erl_cookie
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_ca_ssm_s3_bucket" {
@@ -108,6 +110,7 @@ resource "aws_ssm_parameter" "nerves_hub_ca_ssm_s3_bucket" {
   type      = "String"
   value     = aws_s3_bucket.ca_application_data.bucket
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_ca_ssm_app_name" {
@@ -115,6 +118,7 @@ resource "aws_ssm_parameter" "nerves_hub_ca_ssm_app_name" {
   type      = "String"
   value     = "nerves_hub_ca"
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_ca_ssm_host" {
@@ -122,6 +126,7 @@ resource "aws_ssm_parameter" "nerves_hub_ca_ssm_host" {
   type      = "String"
   value     = "ca.${terraform.workspace}.${var.domain}"
   overwrite = true
+  tags      = var.tags
 }
 
 # Roles
@@ -144,7 +149,7 @@ resource "aws_iam_role" "ca_task_role" {
   ]
 }
 EOF
-
+  tags = var.tags
 }
 
 data "aws_iam_policy_document" "ca_iam_policy" {
@@ -275,6 +280,7 @@ resource "aws_service_discovery_service" "ca_service_discovery" {
   health_check_custom_config {
     failure_threshold = 1
   }
+  tags = var.tags
 }
 
 # ECS

--- a/modules/ca/output.tf
+++ b/modules/ca/output.tf
@@ -6,6 +6,6 @@ output "host" {
   value = "${aws_service_discovery_service.ca_service_discovery.name}.${var.local_dns_namespace.name}"
 }
 
-output "security_group" {
+output "security_group_id" {
   value = aws_security_group.ca_security_group.id
 }

--- a/modules/ca/output.tf
+++ b/modules/ca/output.tf
@@ -5,3 +5,7 @@ output "bucket" {
 output "host" {
   value = "${aws_service_discovery_service.ca_service_discovery.name}.${var.local_dns_namespace.name}"
 }
+
+output "security_group" {
+  value = aws_security_group.ca_security_group.id
+}

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -96,7 +96,7 @@ resource "aws_ssm_parameter" "nerves_hub_device_ssm_s3_log_bucket_name" {
 resource "aws_ssm_parameter" "nerves_hub_device_ssm_app_name" {
   name      = "/${local.device_app_name}/${terraform.workspace}/APP_NAME"
   type      = "String"
-  value     = "${local.device_app_name}"
+  value     = local.device_app_name
   overwrite = true
 }
 

--- a/modules/ecs/cluster/main.tf
+++ b/modules/ecs/cluster/main.tf
@@ -11,7 +11,7 @@ resource "aws_ecs_cluster" "ecs_cluster" {
     for_each = var.settings == "containerInsights" ? [var.settings] : []
     content {
       name  = setting.value
-      value = enabled
+      value = "enabled"
     }
   }
 

--- a/modules/ecs/cluster/main.tf
+++ b/modules/ecs/cluster/main.tf
@@ -26,7 +26,7 @@ resource "aws_security_group" "lb_security_group" {
     from_port = 80
     to_port   = 80
 
-    cidr_blocks = var.whitelist
+    cidr_blocks = var.allow_list
   }
 
   ingress {
@@ -34,7 +34,7 @@ resource "aws_security_group" "lb_security_group" {
     from_port = 443
     to_port   = 443
 
-    cidr_blocks = var.whitelist
+    cidr_blocks = var.allow_list
   }
 
   egress {

--- a/modules/ecs/cluster/main.tf
+++ b/modules/ecs/cluster/main.tf
@@ -7,6 +7,14 @@ data "aws_caller_identity" "current" {}
 resource "aws_ecs_cluster" "ecs_cluster" {
   name = "nerves-hub-${var.environment}"
 
+  dynamic "setting" {
+    for_each = var.settings == "containerInsights" ? [var.settings] : []
+    content {
+      name  = setting.value
+      value = enabled
+    }
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/modules/ecs/cluster/main.tf
+++ b/modules/ecs/cluster/main.tf
@@ -26,7 +26,7 @@ resource "aws_security_group" "lb_security_group" {
     from_port = 80
     to_port   = 80
 
-    cidr_blocks = [element(var.whitelist, count.index)]
+    cidr_blocks = var.whitelist
   }
 
   ingress {
@@ -34,7 +34,7 @@ resource "aws_security_group" "lb_security_group" {
     from_port = 443
     to_port   = 443
 
-    cidr_blocks = [element(var.whitelist, count.index)]
+    cidr_blocks = var.whitelist
   }
 
   egress {

--- a/modules/ecs/cluster/output.tf
+++ b/modules/ecs/cluster/output.tf
@@ -10,6 +10,10 @@ output "arn" {
   value = aws_ecs_cluster.ecs_cluster.arn
 }
 
-output "log_group" {
+output "log_group_name" {
   value = aws_cloudwatch_log_group.app.name
+}
+
+output "log_group_arn" {
+  value = aws_cloudwatch_log_group.app.arn
 }

--- a/modules/ecs/cluster/variables.tf
+++ b/modules/ecs/cluster/variables.tf
@@ -26,6 +26,11 @@ variable "allow_list" {
   description = "IPs that are allowed to access the cluster from load balancers"
 }
 
+variable "settings" {
+  description = "ECS cluster settings"
+  default     = ""
+}
+
 variable "tags" {
   description = "A mapping of tags to assign to the resources"
   type        = map(string)

--- a/modules/ecs/cluster/variables.tf
+++ b/modules/ecs/cluster/variables.tf
@@ -22,7 +22,7 @@ variable "log_retention" {
   description = "Cloud watch log retention days"
 }
 
-variable "whitelist" {
+variable "allow_list" {
   description = "IPs that are allowed to access the cluster from load balancers"
 }
 

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -1,8 +1,39 @@
 # RDS instance security group
 resource "aws_security_group" "rds_security_group" {
   name        = "${var.identifier}-db-sg"
-  description = "${var.identifier}-db-sg"
+  description = "Database security group for ${var.identifier}"
   vpc_id      = var.vpc_id
+
+  dynamic "ingress" {
+    for_each = var.security_groups != [""] ? [var.security_groups] : []
+    content {
+      from_port = 5432
+      protocol = "tcp"
+      to_port = 5432
+      security_groups = flatten([
+        ingress.value
+      ])
+    }
+  }
+
+  dynamic "ingress" {
+    for_each = var.cidr_blocks != [""] ? [var.cidr_blocks] : []
+    content {
+      from_port = 5432
+      protocol = "tcp"
+      to_port = 5432
+      cidr_blocks = flatten([
+        ingress.value
+      ])
+    }
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 
   tags = var.tags
 

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -56,12 +56,17 @@ resource "aws_db_instance" "default" {
   instance_class             = var.instance_class
   username                   = var.username
   password                   = var.password
-  backup_retention_period    = 1
+  backup_retention_period    = var.backup_retention_period
   db_subnet_group_name       = var.subnet_group
-  auto_minor_version_upgrade = true
-  deletion_protection        = false
-  multi_az                   = false
+  auto_minor_version_upgrade = var.auto_minor_version_upgrade
+  deletion_protection        = var.deletion_protection
+  multi_az                   = var.multi_az
+  copy_tags_to_snapshot      = var.copy_tags_to_snapshot
+  option_group_name          = var.option_group_name
   skip_final_snapshot        = true
+
+  performance_insights_enabled    = var.performance_insights
+  enabled_cloudwatch_logs_exports = var.cloudwatch_log_exports
 
   vpc_security_group_ids = [
     aws_security_group.rds_security_group.id,

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -63,6 +63,7 @@ resource "aws_db_instance" "default" {
   multi_az                   = var.multi_az
   copy_tags_to_snapshot      = var.copy_tags_to_snapshot
   option_group_name          = var.option_group_name
+  parameter_group_name       = var.parameter_group_name
   skip_final_snapshot        = true
 
   performance_insights_enabled    = var.performance_insights

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -8,8 +8,8 @@ resource "aws_security_group" "rds_security_group" {
     for_each = var.security_groups != [""] ? [var.security_groups] : []
     content {
       from_port = 5432
-      protocol = "tcp"
-      to_port = 5432
+      protocol  = "tcp"
+      to_port   = 5432
       security_groups = flatten([
         ingress.value
       ])
@@ -20,8 +20,8 @@ resource "aws_security_group" "rds_security_group" {
     for_each = var.cidr_blocks != [""] ? [var.cidr_blocks] : []
     content {
       from_port = 5432
-      protocol = "tcp"
-      to_port = 5432
+      protocol  = "tcp"
+      to_port   = 5432
       cidr_blocks = flatten([
         ingress.value
       ])

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -43,3 +43,11 @@ variable "tags" {
     terraform = true
   }
 }
+
+variable "security_groups" {
+  default = [""]
+}
+
+variable "cidr_blocks" {
+  default = [""]
+}

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -51,3 +51,35 @@ variable "security_groups" {
 variable "cidr_blocks" {
   default = [""]
 }
+
+variable "backup_retention_period" {
+  default = 1
+}
+
+variable "performance_insights" {
+  default = false
+}
+
+variable "auto_minor_version_upgrade" {
+  default = true
+}
+
+variable "deletion_protection" {
+  default = false
+}
+
+variable "multi_az" {
+  default = false
+}
+
+variable "copy_tags_to_snapshot" {
+  default = false
+}
+
+variable "option_group_name" {
+  default = ""
+}
+
+variable "cloudwatch_log_exports" {
+  default = []
+}

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -80,6 +80,10 @@ variable "option_group_name" {
   default = ""
 }
 
+variable "parameter_group_name" {
+  default = ""
+}
+
 variable "cloudwatch_log_exports" {
   default = []
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -5,10 +5,10 @@ module "vpc" {
   name = var.name
   cidr = var.cidr
 
-  azs                 = var.azs
-  private_subnets     = var.private_subnets
-  public_subnets      = var.public_subnets
-  database_subnets    = var.database_subnets
+  azs              = var.azs
+  private_subnets  = var.private_subnets
+  public_subnets   = var.public_subnets
+  database_subnets = var.database_subnets
 
   create_database_subnet_group     = var.create_database_subnet_group
   enable_nat_gateway               = var.enable_nat_gateway

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -25,3 +25,7 @@ output "private_route_table_ids" {
 output "database_route_table_ids" {
   value = module.vpc.database_route_table_ids
 }
+
+output "database_subnet_group" {
+  value = module.vpc.database_subnet_group
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -13,7 +13,7 @@ variable "name" {
 
 variable "cidr" {
   description = "The CIDR block for the vpc"
-  type = string
+  type        = string
 }
 
 variable "public_subnets" {
@@ -33,7 +33,7 @@ variable "database_subnets" {
 
 variable "azs" {
   description = "A list of availability zones names or ids in the region"
-  type = list(string)
+  type        = list(string)
 }
 
 variable "create_database_subnet_group" {

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -231,7 +231,7 @@ resource "aws_iam_role" "www_task_role" {
   ]
 }
 EOF
-  tags = var.tags
+  tags               = var.tags
 }
 
 data "aws_iam_policy_document" "www_iam_policy" {

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -88,6 +88,7 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_secret_db_url" {
   type      = "SecureString"
   value     = "postgres://${var.db.username}:${var.db.password}@${var.db.endpoint}/${var.db.name}"
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_secret_live_view_signing_salt" {
@@ -95,6 +96,7 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_secret_live_view_signing_salt" 
   type      = "SecureString"
   value     = var.live_view_signing_salt
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_secret_erl_cookie" {
@@ -102,6 +104,7 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_secret_erl_cookie" {
   type      = "SecureString"
   value     = var.erl_cookie
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_s3_ssl_bucket" {
@@ -109,6 +112,7 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_s3_ssl_bucket" {
   type      = "String"
   value     = var.ca_bucket
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_app_name" {
@@ -116,6 +120,7 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_app_name" {
   type      = "String"
   value     = "nerves_hub_www"
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_cluster" {
@@ -123,6 +128,7 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_cluster" {
   type      = "String"
   value     = var.cluster.name
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_aws_region" {
@@ -130,6 +136,7 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_aws_region" {
   type      = "String"
   value     = var.region
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_port" {
@@ -137,6 +144,7 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_port" {
   type      = "String"
   value     = 80
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_host" {
@@ -144,6 +152,7 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_host" {
   type      = "String"
   value     = "www.${terraform.workspace}.${var.domain}"
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_s3_bucket_name" {
@@ -151,6 +160,7 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_s3_bucket_name" {
   type      = "String"
   value     = var.app_bucket
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_s3_log_bucket_name" {
@@ -158,6 +168,7 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_s3_log_bucket_name" {
   type      = "String"
   value     = var.log_bucket
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_secret_secret_key_base" {
@@ -165,6 +176,7 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_secret_secret_key_base" {
   type      = "SecureString"
   value     = var.secret_key_base
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_ses_port" {
@@ -172,6 +184,7 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_ses_port" {
   type      = "String"
   value     = "587"
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_ses_server" {
@@ -179,6 +192,7 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_ses_server" {
   type      = "String"
   value     = "email-smtp.${var.region}.amazonaws.com"
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_smtp_username" {
@@ -186,6 +200,7 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_smtp_username" {
   type      = "SecureString"
   value     = var.smtp_password
   overwrite = true
+  tags      = var.tags
 }
 
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_secret_smtp_password" {
@@ -193,6 +208,7 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_secret_smtp_password" {
   type      = "SecureString"
   value     = var.smtp_username
   overwrite = true
+  tags      = var.tags
 }
 
 # Roles
@@ -215,7 +231,7 @@ resource "aws_iam_role" "www_task_role" {
   ]
 }
 EOF
-
+  tags = var.tags
 }
 
 data "aws_iam_policy_document" "www_iam_policy" {

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -393,7 +393,7 @@ resource "aws_ecs_task_definition" "www_task_definition" {
          "logDriver": "awslogs",
          "options": {
            "awslogs-region": "${var.region}",
-           "awslogs-group": "${var.cluster.log_group}",
+           "awslogs-group": "${var.cluster.log_group_name}",
            "awslogs-stream-prefix": "nerves_hub_www"
          }
        }

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -80,8 +80,6 @@ resource "aws_lb_listener" "www_ssl_lb_listener" {
     type             = "forward"
     target_group_arn = aws_lb_target_group.www_lb_tg.arn
   }
-
-  tags = var.tags
 }
 
 # SSM

--- a/setup/variables.tf
+++ b/setup/variables.tf
@@ -125,8 +125,8 @@ variable "api_service_desired_count" {
   default     = "1"
 }
 
-variable "whitelist" {
-  description = "The whitelisted IPs for accessing the cluster"
+variable "allow_list" {
+  description = "The allowed list of IPs for accessing the cluster"
   default     = ["0.0.0.0/0"]
 }
 


### PR DESCRIPTION
## Description

- Decided it might be more flexible and less terraform resources to create a dynamic block in the rds module for adding security group rules and remove them from other tf files
- `modules/ecs/cluster/main.tf` this doesn't work: `[element(var.whitelist, count.index)]`, even with the default use case on master. Count isn't used anywhere for ecs. 

<img width="1259" alt="Screen Shot 2020-11-19 at 8 54 41 AM" src="https://user-images.githubusercontent.com/69476188/99690097-fadf1a00-2a44-11eb-988f-060361c91d55.png">

- `modules/api/main.tf` and `modules/device/main.tf` fix variable format
- `modules/ca/main.tf` missing a `}` causing errors during plan
- alb listener resource does not take tags as a parameter
- add output for `modules/ecs/cluster` `aws_cloudwatch_log_group` `arn` 
- rename output for `log_group` to `log_group_name` and update everywhere
- add dynamic block to `aws_ecs_cluster` for `settings` to allow us to enable containerInsights 
- moar tags!! 

Opening draft PR for visibility but may add/change as needed for deployment of nerves_hub_infrastructure. 