### PR TITLE
TECH-514: Adjust lbs and add ses

### DIFF
--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -29,9 +29,15 @@ resource "aws_lb_target_group" "api_lb_tg" {
 
 resource "aws_lb" "api_lb" {
   name               = "nerves-hub-${terraform.workspace}-api-lb"
-  internal           = false
+  internal           = var.internal_lb
   load_balancer_type = "network"
   subnets            = var.vpc.public_subnets
+
+  access_logs {
+    enabled = var.access_logs
+    bucket  = var.access_logs_bucket
+    prefix  = var.access_logs_prefix
+  }
 
   tags = var.tags
 }

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -35,8 +35,8 @@ resource "aws_lb" "api_lb" {
 
   access_logs {
     enabled = var.access_logs
-    bucket  = var.access_logs_bucket
-    prefix  = var.access_logs_prefix
+    bucket  = var.log_bucket
+    prefix  = var.log_prefix
   }
 
   tags = var.tags

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -35,8 +35,8 @@ resource "aws_lb" "api_lb" {
 
   access_logs {
     enabled = var.access_logs
-    bucket  = var.log_bucket
-    prefix  = var.log_prefix
+    bucket  = var.access_logs_bucket
+    prefix  = var.access_logs_prefix
   }
 
   tags = var.tags

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -166,12 +166,26 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_ses_server" {
   tags      = var.tags
 }
 
+resource "aws_ssm_parameter" "nerves_hub_www_ses_from_email" {
+  name      = "/${local.app_name}/${terraform.workspace}/FROM_EMAIL"
+  type      = "SecureString"
+  value     = var.from_email
+  overwrite = true
+  tags      = var.tags
+}
+
+# Set lifecycle parameter for SMTP creds to avoid sensitive info in tfvars
+# To accommodate for AWS SES Access Keys generated
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_smtp_username" {
   name      = "/${local.app_name}/${terraform.workspace}/SMTP_USERNAME"
   type      = "SecureString"
   value     = var.smtp_password
   overwrite = true
   tags      = var.tags
+
+  lifecycle {
+    ignore_changes = [value]
+  }
 }
 
 resource "aws_ssm_parameter" "nerves_hub_api_ssm_secret_smtp_password" {
@@ -180,6 +194,10 @@ resource "aws_ssm_parameter" "nerves_hub_api_ssm_secret_smtp_password" {
   value     = var.smtp_username
   overwrite = true
   tags      = var.tags
+
+  lifecycle {
+    ignore_changes = [value]
+  }
 }
 
 # Roles

--- a/modules/api/variables.tf
+++ b/modules/api/variables.tf
@@ -18,6 +18,23 @@ variable "smtp_username" {}
 variable "smtp_password" {}
 variable "service_count" {}
 variable "task_execution_role" {}
+//variable "lb_type" {
+//  description = "The type of load balancer to create such as network or application"
+//  default     = "network"
+//}
+variable "access_logs" {
+  default = false
+}
+variable "access_logs_bucket" {
+  default = ""
+}
+variable "access_logs_prefix" {
+  default = ""
+}
+variable "internal_lb" {
+  description = "Whether or not the load balancer is internal"
+  default     = false
+}
 variable "tags" {
   description = "A mapping of tags to assign to the resources"
   type        = map(string)

--- a/modules/api/variables.tf
+++ b/modules/api/variables.tf
@@ -24,8 +24,11 @@ variable "from_email" {
 variable "access_logs" {
   default = false
 }
-variable "log_prefix" {
-  default = "nerves-hub-api-nlb/"
+variable "access_logs_bucket" {
+  default = ""
+}
+variable "access_logs_prefix" {
+  default = "nerves-hub-api-nlb"
 }
 variable "internal_lb" {
   description = "Whether or not the load balancer is internal"

--- a/modules/api/variables.tf
+++ b/modules/api/variables.tf
@@ -24,11 +24,8 @@ variable "from_email" {
 variable "access_logs" {
   default = false
 }
-variable "access_logs_bucket" {
-  default = ""
-}
-variable "access_logs_prefix" {
-  default = ""
+variable "log_prefix" {
+  default = "nerves-hub-api-nlb/"
 }
 variable "internal_lb" {
   description = "Whether or not the load balancer is internal"

--- a/modules/api/variables.tf
+++ b/modules/api/variables.tf
@@ -18,10 +18,9 @@ variable "smtp_username" {}
 variable "smtp_password" {}
 variable "service_count" {}
 variable "task_execution_role" {}
-//variable "lb_type" {
-//  description = "The type of load balancer to create such as network or application"
-//  default     = "network"
-//}
+variable "from_email" {
+  default = "no-reply@nerves-hub.org"
+}
 variable "access_logs" {
   default = false
 }

--- a/modules/ca/main.tf
+++ b/modules/ca/main.tf
@@ -39,7 +39,7 @@ resource "aws_s3_bucket" "ca_application_data" {
   acl    = "private"
 
   versioning {
-    enabled = false
+    enabled = var.s3_versioning
   }
 
   server_side_encryption_configuration {
@@ -56,6 +56,29 @@ resource "aws_s3_bucket" "ca_application_data" {
     target_prefix = var.s3_prefix
   }
   tags = var.tags
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyUnEncryptedTransfers",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::${var.bucket_prefix}-${terraform.workspace}-ca/*",
+        "arn:aws:s3:::${var.bucket_prefix}-${terraform.workspace}-ca"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      }
+    }
+  ]
+}
+EOF
 }
 
 resource "aws_s3_bucket_public_access_block" "ca_application_data" {

--- a/modules/ca/main.tf
+++ b/modules/ca/main.tf
@@ -61,8 +61,10 @@ resource "aws_s3_bucket" "ca_application_data" {
 resource "aws_s3_bucket_public_access_block" "ca_application_data" {
   bucket = aws_s3_bucket.ca_application_data.id
 
-  block_public_acls   = true
-  block_public_policy = true
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 
   depends_on = [
     aws_s3_bucket.ca_application_data

--- a/modules/ca/variables.tf
+++ b/modules/ca/variables.tf
@@ -13,6 +13,9 @@ variable "task_execution_role" {}
 variable "erl_cookie" {}
 variable "web_security_group" {}
 variable "local_dns_namespace" {}
+variable "s3_versioning" {
+  default = false
+}
 
 variable "tags" {
   description = "A mapping of tags to assign to the resources"

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -37,8 +37,8 @@ resource "aws_lb" "device_lb" {
 
   access_logs {
     enabled = var.access_logs
-    bucket  = var.log_bucket
-    prefix  = var.log_prefix
+    bucket  = var.access_logs_bucket
+    prefix  = var.access_logs_prefix
   }
 
   tags = var.tags

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -41,7 +41,7 @@ resource "aws_lb" "device_lb" {
     prefix  = var.access_logs_prefix
   }
 
-  tags               = var.tags
+  tags = var.tags
 }
 
 resource "aws_lb_listener" "device_lb_listener" {
@@ -160,12 +160,26 @@ resource "aws_ssm_parameter" "nerves_hub_device_ssm_ses_server" {
   tags      = var.tags
 }
 
+resource "aws_ssm_parameter" "nerves_hub_www_ses_from_email" {
+  name      = "/${local.device_app_name}/${terraform.workspace}/FROM_EMAIL"
+  type      = "SecureString"
+  value     = var.from_email
+  overwrite = true
+  tags      = var.tags
+}
+
+# Set lifecycle parameter for SMTP creds to avoid sensitive info in tfvars
+# To accommodate for AWS SES Access Keys generated
 resource "aws_ssm_parameter" "nerves_hub_device_ssm_smtp_username" {
   name      = "/${local.device_app_name}/${terraform.workspace}/SMTP_USERNAME"
   type      = "SecureString"
   value     = var.smtp_password
   overwrite = true
   tags      = var.tags
+
+  lifecycle {
+    ignore_changes = [value]
+  }
 }
 
 resource "aws_ssm_parameter" "nerves_hub_device_ssm_secret_smtp_password" {
@@ -174,6 +188,10 @@ resource "aws_ssm_parameter" "nerves_hub_device_ssm_secret_smtp_password" {
   value     = var.smtp_username
   overwrite = true
   tags      = var.tags
+
+  lifecycle {
+    ignore_changes = [value]
+  }
 }
 
 # Roles

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -37,8 +37,8 @@ resource "aws_lb" "device_lb" {
 
   access_logs {
     enabled = var.access_logs
-    bucket  = var.access_logs_bucket
-    prefix  = var.access_logs_prefix
+    bucket  = var.log_bucket
+    prefix  = var.log_prefix
   }
 
   tags = var.tags

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -34,6 +34,13 @@ resource "aws_lb" "device_lb" {
   internal           = false
   load_balancer_type = "network"
   subnets            = var.vpc.public_subnets
+
+  access_logs {
+    enabled = var.access_logs
+    bucket  = var.access_logs_bucket
+    prefix  = var.access_logs_prefix
+  }
+
   tags               = var.tags
 }
 

--- a/modules/device/variables.tf
+++ b/modules/device/variables.tf
@@ -18,6 +18,9 @@ variable "smtp_username" {}
 variable "smtp_password" {}
 variable "service_count" {}
 variable "task_execution_role" {}
+variable "from_email" {
+  default = "no-reply@nerves-hub.org"
+}
 variable "access_logs" {
   default = false
 }

--- a/modules/device/variables.tf
+++ b/modules/device/variables.tf
@@ -18,7 +18,15 @@ variable "smtp_username" {}
 variable "smtp_password" {}
 variable "service_count" {}
 variable "task_execution_role" {}
-
+variable "access_logs" {
+  default = false
+}
+variable "access_logs_bucket" {
+  default = ""
+}
+variable "access_logs_prefix" {
+  default = ""
+}
 variable "tags" {
   description = "A mapping of tags to assign to the resources"
   type        = map(string)

--- a/modules/device/variables.tf
+++ b/modules/device/variables.tf
@@ -24,7 +24,10 @@ variable "from_email" {
 variable "access_logs" {
   default = false
 }
-variable "log_prefix" {
+variable "access_logs_bucket" {
+  default = ""
+}
+variable "access_logs_prefix" {
   default = "nerves-hub-device-nlb"
 }
 variable "tags" {

--- a/modules/device/variables.tf
+++ b/modules/device/variables.tf
@@ -24,11 +24,8 @@ variable "from_email" {
 variable "access_logs" {
   default = false
 }
-variable "access_logs_bucket" {
-  default = ""
-}
-variable "access_logs_prefix" {
-  default = ""
+variable "log_prefix" {
+  default = "nerves-hub-device-nlb"
 }
 variable "tags" {
   description = "A mapping of tags to assign to the resources"

--- a/modules/ses/main.tf
+++ b/modules/ses/main.tf
@@ -34,7 +34,12 @@ data "aws_iam_policy_document" "ses_sendmail" {
       "ses:SendRawEmail"
     ]
     resources = [
-      aws_ses_email_identity.nerves_hub_send.arn
+      "*"
     ]
+    condition {
+      test = "StringEquals"
+      variable = "ses:FromAddress"
+      values = [var.email_identity]
+    }
   }
 }

--- a/modules/ses/main.tf
+++ b/modules/ses/main.tf
@@ -1,0 +1,28 @@
+# SES
+resource "aws_ses_email_identity" "nerves_hub_send" {
+  email = var.email_identity
+}
+
+resource "aws_iam_user" "ses_smtp_user" {
+  name = var.user
+}
+
+resource "aws_iam_policy_attachment" "ses_sendmail" {
+  name = aws_iam_user.ses_smtp_user.name
+  policy_arn = aws_iam_policy.SendRawEmail.arn
+}
+
+resource "aws_iam_policy" "SendRawEmail" {
+  name = var.policy_name
+  policy = data.aws_iam_policy_document.ses_sendmail.json
+}
+
+data "aws_iam_policy_document" "ses_sendmail" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ses:SendRawEmail"
+    ]
+    resources = ["*"]
+  }
+}

--- a/modules/ses/main.tf
+++ b/modules/ses/main.tf
@@ -8,12 +8,13 @@ resource "aws_iam_user" "ses_smtp_user" {
 }
 
 resource "aws_iam_policy_attachment" "ses_sendmail" {
-  name = aws_iam_user.ses_smtp_user.name
+  name       = "ses-sendmail-attachment"
+  users      = [aws_iam_user.ses_smtp_user.name]
   policy_arn = aws_iam_policy.SendRawEmail.arn
 }
 
 resource "aws_iam_policy" "SendRawEmail" {
-  name = var.policy_name
+  name   = var.policy_name
   policy = data.aws_iam_policy_document.ses_sendmail.json
 }
 
@@ -21,8 +22,11 @@ data "aws_iam_policy_document" "ses_sendmail" {
   statement {
     effect = "Allow"
     actions = [
+      "ses:SendEmail",
       "ses:SendRawEmail"
     ]
-    resources = ["*"]
+    resources = [
+      aws_ses_email_identity.nerves_hub_send.arn
+    ]
   }
 }

--- a/modules/ses/main.tf
+++ b/modules/ses/main.tf
@@ -7,9 +7,17 @@ resource "aws_iam_user" "ses_smtp_user" {
   name = var.user
 }
 
-resource "aws_iam_policy_attachment" "ses_sendmail" {
-  name       = "ses-sendmail-attachment"
-  users      = [aws_iam_user.ses_smtp_user.name]
+resource "aws_iam_group" "ses_sendmail" {
+  name = var.group_name
+}
+
+resource "aws_iam_user_group_membership" "ses_sendmail" {
+  groups = [aws_iam_group.ses_sendmail.name]
+  user   = aws_iam_user.ses_smtp_user.name
+}
+
+resource "aws_iam_group_policy_attachment" "ses_sendmail" {
+  group      = aws_iam_group.ses_sendmail.name
   policy_arn = aws_iam_policy.SendRawEmail.arn
 }
 

--- a/modules/ses/variables.tf
+++ b/modules/ses/variables.tf
@@ -1,0 +1,3 @@
+variable "user" {}
+variable "policy_name" {}
+variable "email_identity" {}

--- a/modules/ses/variables.tf
+++ b/modules/ses/variables.tf
@@ -1,3 +1,4 @@
 variable "user" {}
 variable "policy_name" {}
 variable "email_identity" {}
+variable "group_name" {}

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -37,8 +37,8 @@ resource "aws_lb" "www_lb" {
 
   access_logs {
     enabled = var.access_logs
-    bucket  = var.log_bucket
-    prefix  = var.log_prefix
+    bucket  = var.access_logs_bucket
+    prefix  = var.access_logs_prefix
   }
   tags = var.tags
 }

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -37,10 +37,10 @@ resource "aws_lb" "www_lb" {
 
   access_logs {
     enabled = var.access_logs
-    bucket = var.access_logs_bucket
-    prefix = var.access_logs_prefix
+    bucket  = var.access_logs_bucket
+    prefix  = var.access_logs_prefix
   }
-  tags               = var.tags
+  tags = var.tags
 }
 
 resource "aws_lb_listener" "www_lb_listener" {
@@ -164,6 +164,14 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_secret_secret_key_base" {
   tags      = var.tags
 }
 
+resource "aws_ssm_parameter" "nerves_hub_www_ses_from_email" {
+  name      = "/nerves_hub_www/${terraform.workspace}/FROM_EMAIL"
+  type      = "SecureString"
+  value     = var.from_email
+  overwrite = true
+  tags      = var.tags
+}
+
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_ses_port" {
   name      = "/nerves_hub_www/${terraform.workspace}/SES_PORT"
   type      = "String"
@@ -180,12 +188,18 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_ses_server" {
   tags      = var.tags
 }
 
+# Set lifecycle parameter for SMTP creds to avoid sensitive info in tfvars
+# To accommodate for AWS SES Access Keys generated
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_smtp_username" {
   name      = "/nerves_hub_www/${terraform.workspace}/SMTP_USERNAME"
   type      = "SecureString"
   value     = var.smtp_password
   overwrite = true
   tags      = var.tags
+
+  lifecycle {
+    ignore_changes = [value]
+  }
 }
 
 resource "aws_ssm_parameter" "nerves_hub_www_ssm_secret_smtp_password" {
@@ -194,6 +208,10 @@ resource "aws_ssm_parameter" "nerves_hub_www_ssm_secret_smtp_password" {
   value     = var.smtp_username
   overwrite = true
   tags      = var.tags
+
+  lifecycle {
+    ignore_changes = [value]
+  }
 }
 
 # Roles

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -30,10 +30,16 @@ resource "aws_lb_target_group" "www_lb_tg" {
 
 resource "aws_lb" "www_lb" {
   name               = "nerves-hub-${terraform.workspace}-www-lb"
-  internal           = false
+  internal           = var.internal_lb
   load_balancer_type = "application"
   security_groups    = [var.lb_security_group_id]
   subnets            = var.vpc.public_subnets
+
+  access_logs {
+    enabled = var.access_logs
+    bucket = var.access_logs_bucket
+    prefix = var.access_logs_prefix
+  }
   tags               = var.tags
 }
 

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -37,8 +37,8 @@ resource "aws_lb" "www_lb" {
 
   access_logs {
     enabled = var.access_logs
-    bucket  = var.access_logs_bucket
-    prefix  = var.access_logs_prefix
+    bucket  = var.log_bucket
+    prefix  = var.log_prefix
   }
   tags = var.tags
 }
@@ -49,8 +49,13 @@ resource "aws_lb_listener" "www_lb_listener" {
   protocol          = "HTTP"
 
   default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.www_lb_tg.arn
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
   }
 }
 

--- a/modules/www/variables.tf
+++ b/modules/www/variables.tf
@@ -20,7 +20,19 @@ variable "smtp_password" {}
 variable "service_count" {}
 variable "task_execution_role" {}
 variable "certificate_arn" {}
-
+variable "access_logs" {
+  default = false
+}
+variable "access_logs_bucket" {
+  default = ""
+}
+variable "access_logs_prefix" {
+  default = ""
+}
+variable "internal_lb" {
+  description = "Whether or not the load balancer is internal"
+  default     = false
+}
 variable "tags" {
   description = "A mapping of tags to assign to the resources"
   type        = map(string)

--- a/modules/www/variables.tf
+++ b/modules/www/variables.tf
@@ -26,7 +26,10 @@ variable "from_email" {
 variable "access_logs" {
   default = false
 }
-variable "log_prefix" {
+variable "access_logs_bucket" {
+  default = ""
+}
+variable "access_logs_prefix" {
   default = "nerves-hub-www-alb"
 }
 variable "internal_lb" {

--- a/modules/www/variables.tf
+++ b/modules/www/variables.tf
@@ -20,6 +20,9 @@ variable "smtp_password" {}
 variable "service_count" {}
 variable "task_execution_role" {}
 variable "certificate_arn" {}
+variable "from_email" {
+  default = "no-reply@nerves-hub.org"
+}
 variable "access_logs" {
   default = false
 }

--- a/modules/www/variables.tf
+++ b/modules/www/variables.tf
@@ -26,11 +26,8 @@ variable "from_email" {
 variable "access_logs" {
   default = false
 }
-variable "access_logs_bucket" {
-  default = ""
-}
-variable "access_logs_prefix" {
-  default = ""
+variable "log_prefix" {
+  default = "nerves-hub-www-alb"
 }
 variable "internal_lb" {
   description = "Whether or not the load balancer is internal"


### PR DESCRIPTION
## Description 

- Added `ignore_public_acls` and `restrict_public_buckets` to ca module s3 bucket for ssl certs
- Added some Qualys remediations for alb (redirect traffic to 443 and add s3 bucket policy for ca ssl bucket)
- Adding variable for internal LB options for api and www LBs 
- Adding access_logs vars for optional configuration of LB access logging 
- Adding an SES module to allow for creation and management of resources 
- IAM group attachment best practice rather than attached directly to user
- Adding lifecycle ignore_changes for smtp credentials ssm parameters. This is since SES requires converted IAM user keys to be used for smtp credentials. To avoid having plain text passwords in either tfvars (defining them there) or requiring the `aws_iam_user` resource from generating them (which stores them in plain text in the tfstate file). This lets us set a generic `changeme` style variable and update them later. 
- Adding FROM_EMAIL ssm parameter in api/device/www modules since default is set within the application to `no-reply@nerves-hub.org` 
Ref: https://docs.nerves-hub.org/nerves-hub/custom-deployment/configure-ses 
https://github.com/nerves-hub/nerves_hub_web/blob/b9528338247a4e0a40961f4deff79a9ada0734ee/apps/nerves_hub_www/config/release.exs#L56
https://github.com/nerves-hub/nerves_hub_web/blob/b9528338247a4e0a40961f4deff79a9ada0734ee/apps/nerves_hub_device/config/release.exs#L32
https://github.com/nerves-hub/nerves_hub_web/blob/b9528338247a4e0a40961f4deff79a9ada0734ee/apps/nerves_hub_api/config/release.exs#L32
<img width="1683" alt="Screen Shot 2020-12-04 at 4 53 29 PM" src="https://user-images.githubusercontent.com/69476188/101226324-54546500-3651-11eb-9fa5-ddc702e766b0.png">