### PR TITLE
TECH-593: Tech updates

### DIFF
--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -313,37 +313,44 @@ data "aws_iam_policy_document" "api_iam_policy" {
 
   statement {
     actions = [
-      "ecs:DeregisterContainerInstance",
-      "ecs:DiscoverPollEndpoint",
-      "ecs:Poll",
-      "ecs:RegisterContainerInstance",
-      "ecs:StartTelemetrySession",
-      "ecs:UpdateContainerInstancesState",
-      "ecs:Submit*",
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-      "ecs:RegisterContainerInstance",
-      "ecs:DeregisterContainerInstance",
-      "ecs:DiscoverPollEndpoint",
       "ecs:StartTask",
-      "ecs:ListTasks",
-      "ecs:ListServices",
+      "ecs:Submit*",
+      "ecs:RegisterContainerInstance",
+      "ecs:DeregisterContainerInstance",
       "ecs:DescribeServices",
       "ecs:DescribeTasks",
+    ]
+
+    resources = [
+      aws_ecs_service.api_ecs_service.cluster,
+      aws_ecs_service.api_ecs_service.id,
+      "arn:aws:ecs:${var.region}:${var.account_id}:task-definition/nerves-hub-${terraform.workspace}-api:*",
+      "arn:aws:ecs:${var.region}:${var.account_id}:task/nerves-hub-${terraform.workspace}/*"
+    ]
+  }
+
+  statement {
+    actions = [
       "logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
       "logs:DescribeLogStreams",
+      "ecs:DiscoverPollEndpoint",
+      "ecs:Poll",
+      "ecs:StartTelemetrySession",
+      "ecs:UpdateContainerInstancesState",
+      "ecs:DiscoverPollEndpoint",
+      "ecs:ListTasks",
+      "ecs:ListServices",
     ]
 
     resources = [
       "*",
     ]
   }
+}
+
+resource "aws_iam_role_policy_attachment" "aws_managed_task_execution_role_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+  role = aws_iam_role.api_task_role.name
 }
 
 resource "aws_iam_policy" "api_task_policy" {

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -321,9 +321,7 @@ data "aws_iam_policy_document" "api_iam_policy" {
 
     resources = [
       aws_ecs_service.api_ecs_service.cluster,
-      aws_ecs_service.api_ecs_service.id,
       "arn:aws:ecs:${var.region}:${var.account_id}:task-definition/nerves-hub-${terraform.workspace}-api:*",
-      "arn:aws:ecs:${var.region}:${var.account_id}:task/nerves-hub-${terraform.workspace}/*"
     ]
   }
 

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -313,12 +313,12 @@ data "aws_iam_policy_document" "api_iam_policy" {
 
   statement {
     actions = [
-      "ecs:StartTask",
-      "ecs:Submit*",
-      "ecs:RegisterContainerInstance",
       "ecs:DeregisterContainerInstance",
       "ecs:DescribeServices",
       "ecs:DescribeTasks",
+      "ecs:RegisterContainerInstance",
+      "ecs:StartTask",
+      "ecs:Submit*",
     ]
 
     resources = [
@@ -331,15 +331,14 @@ data "aws_iam_policy_document" "api_iam_policy" {
 
   statement {
     actions = [
-      "logs:CreateLogGroup",
-      "logs:DescribeLogStreams",
       "ecs:DiscoverPollEndpoint",
+      "ecs:ListServices",
+      "ecs:ListTasks",
       "ecs:Poll",
       "ecs:StartTelemetrySession",
       "ecs:UpdateContainerInstancesState",
-      "ecs:DiscoverPollEndpoint",
-      "ecs:ListTasks",
-      "ecs:ListServices",
+      "logs:CreateLogGroup",
+      "logs:DescribeLogStreams",
     ]
 
     resources = [

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -314,8 +314,6 @@ data "aws_iam_policy_document" "api_iam_policy" {
   statement {
     actions = [
       "ecs:DeregisterContainerInstance",
-      "ecs:DescribeServices",
-      "ecs:DescribeTasks",
       "ecs:RegisterContainerInstance",
       "ecs:StartTask",
       "ecs:Submit*",
@@ -331,6 +329,8 @@ data "aws_iam_policy_document" "api_iam_policy" {
 
   statement {
     actions = [
+      "ecs:DescribeServices",
+      "ecs:DescribeTasks",
       "ecs:DiscoverPollEndpoint",
       "ecs:ListServices",
       "ecs:ListTasks",

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -345,11 +345,6 @@ data "aws_iam_policy_document" "api_iam_policy" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "aws_managed_task_execution_role_policy" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
-  role = aws_iam_role.api_task_role.name
-}
-
 resource "aws_iam_policy" "api_task_policy" {
   name   = "nerves-hub-${terraform.workspace}-api-task-policy"
   policy = data.aws_iam_policy_document.api_iam_policy.json

--- a/modules/ca/main.tf
+++ b/modules/ca/main.tf
@@ -257,9 +257,7 @@ data "aws_iam_policy_document" "ca_iam_policy" {
 
     resources = [
       aws_ecs_service.ca_ecs_service.cluster,
-      aws_ecs_service.ca_ecs_service.id,
       "arn:aws:ecs:${var.region}:${var.account_id}:task-definition/nerves-hub-${terraform.workspace}-ca:*",
-      "arn:aws:ecs:${var.region}:${var.account_id}:task/nerves-hub-${terraform.workspace}/*"
     ]
   }
 

--- a/modules/ca/main.tf
+++ b/modules/ca/main.tf
@@ -277,11 +277,6 @@ data "aws_iam_policy_document" "ca_iam_policy" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "aws_managed_task_execution_role_policy" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
-  role = aws_iam_role.ca_task_role.name
-}
-
 resource "aws_iam_policy" "ca_task_policy" {
   name   = "nerves-hub-${terraform.workspace}-ca-task-policy"
   policy = data.aws_iam_policy_document.ca_iam_policy.json

--- a/modules/ca/main.tf
+++ b/modules/ca/main.tf
@@ -249,27 +249,29 @@ data "aws_iam_policy_document" "ca_iam_policy" {
 
   statement {
     actions = [
-      "ecs:DeregisterContainerInstance",
-      "ecs:DiscoverPollEndpoint",
-      "ecs:Poll",
+      "ecs:Submit*",
       "ecs:RegisterContainerInstance",
+      "ecs:DeregisterContainerInstance",
+      "ecs:StartTask",
+    ]
+
+    resources = [
+      aws_ecs_service.ca_ecs_service.cluster,
+      aws_ecs_service.ca_ecs_service.id,
+      "arn:aws:ecs:${var.region}:${var.account_id}:task-definition/nerves-hub-${terraform.workspace}-ca:*",
+      "arn:aws:ecs:${var.region}:${var.account_id}:task/nerves-hub-${terraform.workspace}/*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:DescribeLogStreams",
+      "ecs:DiscoverPollEndpoint",
       "ecs:StartTelemetrySession",
       "ecs:UpdateContainerInstancesState",
-      "ecs:Submit*",
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-      "ecs:RegisterContainerInstance",
-      "ecs:DeregisterContainerInstance",
       "ecs:DiscoverPollEndpoint",
-      "ecs:StartTask",
-      "logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-      "logs:DescribeLogStreams",
+      "ecs:Poll",
     ]
 
     resources = [
@@ -278,6 +280,10 @@ data "aws_iam_policy_document" "ca_iam_policy" {
   }
 }
 
+resource "aws_iam_role_policy_attachment" "aws_managed_task_execution_role_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+  role = aws_iam_role.ca_task_role.name
+}
 
 resource "aws_iam_policy" "ca_task_policy" {
   name   = "nerves-hub-${terraform.workspace}-ca-task-policy"

--- a/modules/ca/main.tf
+++ b/modules/ca/main.tf
@@ -249,10 +249,10 @@ data "aws_iam_policy_document" "ca_iam_policy" {
 
   statement {
     actions = [
-      "ecs:Submit*",
-      "ecs:RegisterContainerInstance",
       "ecs:DeregisterContainerInstance",
+      "ecs:RegisterContainerInstance",
       "ecs:StartTask",
+      "ecs:Submit*",
     ]
 
     resources = [
@@ -265,13 +265,12 @@ data "aws_iam_policy_document" "ca_iam_policy" {
 
   statement {
     actions = [
-      "logs:CreateLogGroup",
-      "logs:DescribeLogStreams",
-      "ecs:DiscoverPollEndpoint",
-      "ecs:StartTelemetrySession",
-      "ecs:UpdateContainerInstancesState",
       "ecs:DiscoverPollEndpoint",
       "ecs:Poll",
+      "ecs:StartTelemetrySession",
+      "ecs:UpdateContainerInstancesState",
+      "logs:CreateLogGroup",
+      "logs:DescribeLogStreams",
     ]
 
     resources = [

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -307,8 +307,6 @@ data "aws_iam_policy_document" "device_iam_policy" {
   statement {
     actions = [
       "ecs:DeregisterContainerInstance",
-      "ecs:DescribeServices",
-      "ecs:DescribeTasks",
       "ecs:RegisterContainerInstance",
       "ecs:StartTask",
       "ecs:Submit*",
@@ -324,6 +322,8 @@ data "aws_iam_policy_document" "device_iam_policy" {
 
   statement {
     actions = [
+      "ecs:DescribeServices",
+      "ecs:DescribeTasks",
       "ecs:DiscoverPollEndpoint",
       "ecs:ListServices",
       "ecs:ListTasks",

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -314,9 +314,7 @@ data "aws_iam_policy_document" "device_iam_policy" {
 
     resources = [
       aws_ecs_service.device_ecs_service.cluster,
-      aws_ecs_service.device_ecs_service.id,
       "arn:aws:ecs:${var.region}:${var.account_id}:task-definition/nerves-hub-${terraform.workspace}-device:*",
-      "arn:aws:ecs:${var.region}:${var.account_id}:task/nerves-hub-${terraform.workspace}/*"
     ]
   }
 

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -306,11 +306,11 @@ data "aws_iam_policy_document" "device_iam_policy" {
 
   statement {
     actions = [
-      "ecs:RegisterContainerInstance",
       "ecs:DeregisterContainerInstance",
-      "ecs:StartTask",
       "ecs:DescribeServices",
       "ecs:DescribeTasks",
+      "ecs:RegisterContainerInstance",
+      "ecs:StartTask",
       "ecs:Submit*",
     ]
 
@@ -324,15 +324,14 @@ data "aws_iam_policy_document" "device_iam_policy" {
 
   statement {
     actions = [
-      "logs:CreateLogGroup",
-      "logs:DescribeLogStreams",
       "ecs:DiscoverPollEndpoint",
+      "ecs:ListServices",
+      "ecs:ListTasks",
       "ecs:Poll",
       "ecs:StartTelemetrySession",
       "ecs:UpdateContainerInstancesState",
-      "ecs:ListTasks",
-      "ecs:ListServices",
-      "ecs:DiscoverPollEndpoint",
+      "logs:CreateLogGroup",
+      "logs:DescribeLogStreams",
     ]
 
     resources = [

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -338,11 +338,6 @@ data "aws_iam_policy_document" "device_iam_policy" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "aws_managed_task_execution_role_policy" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
-  role = aws_iam_role.device_task_role.name
-}
-
 resource "aws_iam_policy" "device_task_policy" {
   name   = "nerves-hub-${terraform.workspace}-device-task-policy"
   policy = data.aws_iam_policy_document.device_iam_policy.json

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -306,37 +306,44 @@ data "aws_iam_policy_document" "device_iam_policy" {
 
   statement {
     actions = [
-      "ecs:DeregisterContainerInstance",
-      "ecs:DiscoverPollEndpoint",
-      "ecs:Poll",
-      "ecs:RegisterContainerInstance",
-      "ecs:StartTelemetrySession",
-      "ecs:UpdateContainerInstancesState",
-      "ecs:Submit*",
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
       "ecs:RegisterContainerInstance",
       "ecs:DeregisterContainerInstance",
-      "ecs:DiscoverPollEndpoint",
       "ecs:StartTask",
-      "ecs:ListTasks",
-      "ecs:ListServices",
       "ecs:DescribeServices",
       "ecs:DescribeTasks",
+      "ecs:Submit*",
+    ]
+
+    resources = [
+      aws_ecs_service.device_ecs_service.cluster,
+      aws_ecs_service.device_ecs_service.id,
+      "arn:aws:ecs:${var.region}:${var.account_id}:task-definition/nerves-hub-${terraform.workspace}-device:*",
+      "arn:aws:ecs:${var.region}:${var.account_id}:task/nerves-hub-${terraform.workspace}/*"
+    ]
+  }
+
+  statement {
+    actions = [
       "logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
       "logs:DescribeLogStreams",
+      "ecs:DiscoverPollEndpoint",
+      "ecs:Poll",
+      "ecs:StartTelemetrySession",
+      "ecs:UpdateContainerInstancesState",
+      "ecs:ListTasks",
+      "ecs:ListServices",
+      "ecs:DiscoverPollEndpoint",
     ]
 
     resources = [
       "*",
     ]
   }
+}
+
+resource "aws_iam_role_policy_attachment" "aws_managed_task_execution_role_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+  role = aws_iam_role.device_task_role.name
 }
 
 resource "aws_iam_policy" "device_task_policy" {

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -85,7 +85,7 @@ resource "aws_db_instance" "default" {
 }
 
 resource "aws_db_parameter_group" "this" {
-  name_prefix = var.identifier
+  name_prefix = "${var.identifier}-"
   description = "Database Parameter Group for ${var.identifier}"
   family      = var.family
 

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -85,7 +85,7 @@ resource "aws_db_instance" "default" {
 }
 
 resource "aws_db_parameter_group" "this" {
-  name        = var.identifier
+  name_prefix = var.identifier
   description = "Database Parameter Group for ${var.identifier}"
   family      = var.family
 

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -1,3 +1,8 @@
+locals {
+  parameter_group_name = var.create ? var.name : var.parameter_group_name
+  option_group_name    = var.create ? var.name : var.option_group_name
+}
+
 # RDS instance security group
 resource "aws_security_group" "rds_security_group" {
   name        = "${var.identifier}-db-sg"
@@ -64,8 +69,8 @@ resource "aws_db_instance" "default" {
   deletion_protection        = var.deletion_protection
   multi_az                   = var.multi_az
   copy_tags_to_snapshot      = var.copy_tags_to_snapshot
-  option_group_name          = var.option_group_name
-  parameter_group_name       = var.parameter_group_name
+  option_group_name          = local.option_group_name
+  parameter_group_name       = local.parameter_group_name
   skip_final_snapshot        = true
 
   performance_insights_enabled    = var.performance_insights
@@ -82,4 +87,65 @@ resource "aws_db_instance" "default" {
   }
 
   tags = var.tags
+}
+
+resource "aws_db_parameter_group" "this" {
+  count = var.create ? 1 : 0
+
+  name        = var.name
+  description = "Parameter Group for ${var.name}"
+  family      = var.family
+
+  dynamic "parameter" {
+    for_each = var.parameters
+    content {
+      name         = parameter.value.name
+      value        = parameter.value.value
+      apply_method = lookup(parameter.value, "apply_method", null)
+    }
+  }
+
+  tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_db_option_group" "this" {
+  count = var.create ? 1 : 0
+
+  name_prefix              = var.name
+  option_group_description = "Option group for ${var.name}"
+  engine_name              = "postgres"
+  major_engine_version     = var.major_engine_version
+
+  dynamic "option" {
+    for_each = var.options
+    content {
+      option_name                    = option.value.option_name
+      port                           = lookup(option.value, "port", null)
+      version                        = lookup(option.value, "version", null)
+      db_security_group_memberships  = lookup(option.value, "db_security_group_memberships", null)
+      vpc_security_group_memberships = lookup(option.value, "vpc_security_group_memberships", null)
+
+      dynamic "option_settings" {
+        for_each = lookup(option.value, "option_settings", [])
+        content {
+          name  = lookup(option_settings.value, "name", null)
+          value = lookup(option_settings.value, "value", null)
+        }
+      }
+    }
+  }
+
+  tags = var.tags
+
+  timeouts {
+    delete = lookup(var.timeouts, "delete", null)
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -1,8 +1,3 @@
-locals {
-  parameter_group_name = var.create ? var.name : var.parameter_group_name
-  option_group_name    = var.create ? var.name : var.option_group_name
-}
-
 # RDS instance security group
 resource "aws_security_group" "rds_security_group" {
   name        = "${var.identifier}-db-sg"
@@ -69,8 +64,8 @@ resource "aws_db_instance" "default" {
   deletion_protection        = var.deletion_protection
   multi_az                   = var.multi_az
   copy_tags_to_snapshot      = var.copy_tags_to_snapshot
-  option_group_name          = local.option_group_name
-  parameter_group_name       = local.parameter_group_name
+  option_group_name          = aws_db_option_group.this.name
+  parameter_group_name       = aws_db_parameter_group.this.name
   skip_final_snapshot        = true
 
   performance_insights_enabled    = var.performance_insights
@@ -90,8 +85,6 @@ resource "aws_db_instance" "default" {
 }
 
 resource "aws_db_parameter_group" "this" {
-  count = var.create ? 1 : 0
-
   name        = var.name
   description = "Parameter Group for ${var.name}"
   family      = var.family
@@ -113,9 +106,7 @@ resource "aws_db_parameter_group" "this" {
 }
 
 resource "aws_db_option_group" "this" {
-  count = var.create ? 1 : 0
-
-  name_prefix              = var.name
+  name_prefix              = "${var.name}-"
   option_group_description = "Option group for ${var.name}"
   engine_name              = "postgres"
   major_engine_version     = var.major_engine_version

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -85,8 +85,8 @@ resource "aws_db_instance" "default" {
 }
 
 resource "aws_db_parameter_group" "this" {
-  name        = var.name
-  description = "Parameter Group for ${var.name}"
+  name        = var.identifier
+  description = "Database Parameter Group for ${var.identifier}"
   family      = var.family
 
   dynamic "parameter" {
@@ -106,8 +106,8 @@ resource "aws_db_parameter_group" "this" {
 }
 
 resource "aws_db_option_group" "this" {
-  name_prefix              = "${var.name}-"
-  option_group_description = "Option group for ${var.name}"
+  name_prefix              = "${var.identifier}-"
+  option_group_description = "Database Option group for ${var.identifier}"
   engine_name              = "postgres"
   major_engine_version     = var.major_engine_version
 

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -88,12 +88,8 @@ variable "cloudwatch_log_exports" {
   default = []
 }
 
-variable "create" {
-  default = false
-}
-
 variable "family" {
-  default = ""
+  default = "postgres11"
 }
 
 variable "parameters" {

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -87,3 +87,31 @@ variable "parameter_group_name" {
 variable "cloudwatch_log_exports" {
   default = []
 }
+
+variable "create" {
+  default = false
+}
+
+variable "family" {
+  default = ""
+}
+
+variable "parameters" {
+  default = []
+}
+
+variable "options" {
+  default = []
+}
+
+variable "major_engine_version" {
+  default = 11
+}
+
+variable "timeouts" {
+  description = "Define maximum timeout for deletion of `aws_db_option_group` resource"
+  type        = map(string)
+  default = {
+    delete = "15m"
+  }
+}

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -364,11 +364,6 @@ data "aws_iam_policy_document" "www_iam_policy" {
   }
 }
 
-resource "aws_iam_role_policy_attachment" "aws_managed_task_execution_role_policy" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
-  role = aws_iam_role.www_task_role.name
-}
-
 resource "aws_iam_policy" "www_task_policy" {
   name   = "nerves-hub-${terraform.workspace}-www-task-policy"
   policy = data.aws_iam_policy_document.www_iam_policy.json

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -332,12 +332,12 @@ data "aws_iam_policy_document" "www_iam_policy" {
 
   statement {
     actions = [
-      "ecs:Submit*",
-      "ecs:RegisterContainerInstance",
       "ecs:DeregisterContainerInstance",
-      "ecs:StartTask",
       "ecs:DescribeServices",
       "ecs:DescribeTasks",
+      "ecs:RegisterContainerInstance",
+      "ecs:StartTask",
+      "ecs:Submit*",
     ]
 
     resources = [
@@ -351,12 +351,11 @@ data "aws_iam_policy_document" "www_iam_policy" {
   statement {
     actions = [
       "ecs:DiscoverPollEndpoint",
+      "ecs:ListServices",
+      "ecs:ListTasks",
       "ecs:Poll",
       "ecs:StartTelemetrySession",
       "ecs:UpdateContainerInstancesState",
-      "ecs:DiscoverPollEndpoint",
-      "ecs:ListTasks",
-      "ecs:ListServices",
       "logs:CreateLogGroup",
       "logs:DescribeLogStreams",
     ]

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -332,30 +332,32 @@ data "aws_iam_policy_document" "www_iam_policy" {
 
   statement {
     actions = [
-      "ecs:DeregisterContainerInstance",
-      "ecs:DiscoverPollEndpoint",
-      "ecs:Poll",
-      "ecs:RegisterContainerInstance",
-      "ecs:StartTelemetrySession",
-      "ecs:UpdateContainerInstancesState",
       "ecs:Submit*",
-      "ecr:GetAuthorizationToken",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
       "ecs:RegisterContainerInstance",
       "ecs:DeregisterContainerInstance",
-      "ecs:DiscoverPollEndpoint",
       "ecs:StartTask",
-      "ecs:ListTasks",
-      "ecs:ListServices",
       "ecs:DescribeServices",
       "ecs:DescribeTasks",
+    ]
+
+    resources = [
+      aws_ecs_service.www_ecs_service.cluster,
+      aws_ecs_service.www_ecs_service.id,
+      "arn:aws:ecs:${var.region}:${var.account_id}:task-definition/nerves-hub-${terraform.workspace}-www:*",
+      "arn:aws:ecs:${var.region}:${var.account_id}:task/nerves-hub-${terraform.workspace}/*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "ecs:DiscoverPollEndpoint",
+      "ecs:Poll",
+      "ecs:StartTelemetrySession",
+      "ecs:UpdateContainerInstancesState",
+      "ecs:DiscoverPollEndpoint",
+      "ecs:ListTasks",
+      "ecs:ListServices",
       "logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
       "logs:DescribeLogStreams",
     ]
 
@@ -365,6 +367,10 @@ data "aws_iam_policy_document" "www_iam_policy" {
   }
 }
 
+resource "aws_iam_role_policy_attachment" "aws_managed_task_execution_role_policy" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+  role = aws_iam_role.www_task_role.name
+}
 
 resource "aws_iam_policy" "www_task_policy" {
   name   = "nerves-hub-${terraform.workspace}-www-task-policy"

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -340,9 +340,7 @@ data "aws_iam_policy_document" "www_iam_policy" {
 
     resources = [
       aws_ecs_service.www_ecs_service.cluster,
-      aws_ecs_service.www_ecs_service.id,
       "arn:aws:ecs:${var.region}:${var.account_id}:task-definition/nerves-hub-${terraform.workspace}-www:*",
-      "arn:aws:ecs:${var.region}:${var.account_id}:task/nerves-hub-${terraform.workspace}/*"
     ]
   }
 

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -333,8 +333,6 @@ data "aws_iam_policy_document" "www_iam_policy" {
   statement {
     actions = [
       "ecs:DeregisterContainerInstance",
-      "ecs:DescribeServices",
-      "ecs:DescribeTasks",
       "ecs:RegisterContainerInstance",
       "ecs:StartTask",
       "ecs:Submit*",
@@ -350,6 +348,8 @@ data "aws_iam_policy_document" "www_iam_policy" {
 
   statement {
     actions = [
+      "ecs:DescribeServices",
+      "ecs:DescribeTasks",
       "ecs:DiscoverPollEndpoint",
       "ecs:ListServices",
       "ecs:ListTasks",


### PR DESCRIPTION
# Description 

## ECS Task Role policies
Resource is restricted to cluster:
- ecs:DeregisterContainerInstance
- ecs:RegisterContainerInstance

Resource is restricted to task-definition per service (device/api/www/ca). I don't see anything suggesting each service needs to start another service's task.
- ecs:StartTask

Removed these actions altogether since they're in the task execution role (see app.tf) and I don't see why the containers would need these:
- ecr:GetAuthorizationToken
- ecr:BatchCheckLayerAvailability
- ecr:GetDownloadUrlForLayer
- ecr:BatchGetImage
- logs:CreateLogStream
- logs:PutLogEvents

Removed several duplicate actions in places. 

After some digging, found that the nerves-hub images for www/device/api run commands for describe-services, list-tasks, describe-tasks on startup. Looks like this is done so each node can identify each other. Left `*` for resource on those. 
Ex: https://github.com/nerves-hub/nerves_hub_web/blob/52c1b3a71ee30cb3235c76bf7e03345b81df0cd3/apps/nerves_hub_www/rel/Dockerfile.build#L60
Script: https://github.com/nerves-hub/nerves_hub_web/blob/main/rel/scripts/ecs-cluster.sh

<img width="916" alt="Screen Shot 2020-12-17 at 3 24 51 PM" src="https://user-images.githubusercontent.com/69476188/102550976-06415780-407c-11eb-9959-4e7169de55e6.png">

## RDS Custom Parameter and Option Groups
- Add a parameter and option group for each RDS instance 

## Tests
1. Deployed to nerves-hub dev env 
2. Create new task definitions 
3. Run task def update and deploy/migrations script
4. Confirmed services are scaled in, containers can pull images
5. Confirmed no errors in task logs, logs show certs pulled from ca s3 bucket
6. Confirm login to web interface
7. Parameter and Option groups applied to the DBs with a reboot
