### PR TITLE
Adding the epmd port to the port mappings in the container def

### DIFF
--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -376,6 +376,11 @@ resource "aws_ecs_task_definition" "api_task_definition" {
            "hostPort": 443,
            "protocol": "tcp",
            "containerPort": 443
+         },
+         {
+           "hostPort": 4369,
+           "protocol": "tcp",
+           "containerPort": 4369
          }
        ],
        "networkMode": "awsvpc",

--- a/modules/billing/main.tf
+++ b/modules/billing/main.tf
@@ -290,6 +290,11 @@ resource "aws_ecs_task_definition" "billing_task_definition" {
            "hostPort": 8443,
            "protocol": "tcp",
            "containerPort": 8443
+         },
+         {
+           "hostPort": 4369,
+           "protocol": "tcp",
+           "containerPort": 4369
          }
        ],
        "networkMode": "awsvpc",

--- a/modules/ca/main.tf
+++ b/modules/ca/main.tf
@@ -329,6 +329,11 @@ resource "aws_ecs_task_definition" "ca_task_definition" {
            "hostPort": 8443,
            "protocol": "tcp",
            "containerPort": 8443
+         },
+         {
+           "hostPort": 4369,
+           "protocol": "tcp",
+           "containerPort": 4369
          }
        ],
        "networkMode": "awsvpc",

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -367,6 +367,11 @@ resource "aws_ecs_task_definition" "device_task_definition" {
            "hostPort": 443,
            "protocol": "tcp",
            "containerPort": 443
+         },
+         {
+           "hostPort": 4369,
+           "protocol": "tcp",
+           "containerPort": 4369
          }
        ],
        "networkMode": "awsvpc",

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -394,6 +394,11 @@ resource "aws_ecs_task_definition" "www_task_definition" {
            "hostPort": 80,
            "protocol": "tcp",
            "containerPort": 80
+         },
+         {
+           "hostPort": 4369,
+           "protocol": "tcp",
+           "containerPort": 4369
          }
        ],
        "networkMode": "awsvpc",


### PR DESCRIPTION
We already have the security group rules allowing TCP traffic to these ports, we're just not exposing the port to the docker container. This is why I'm suspect that clustering isn't working. 