### PR TITLE
TECH: API ALB Options

### DIFF
--- a/modules/api/alb.tf
+++ b/modules/api/alb.tf
@@ -29,7 +29,7 @@ resource "aws_lb" "api_alb" {
   name               = "nerves-hub-${terraform.workspace}-api-alb"
   internal           = var.internal_alb
   load_balancer_type = "application"
-  security_groups    = [aws_security_group.port80_lb_security_group.id, aws_security_group.port443_lb_security_group.id]
+  security_groups    = [aws_security_group.port80_lb_security_group[count.index].id, aws_security_group.port443_lb_security_group[count.index].id]
   subnets            = var.vpc.public_subnets
 
   access_logs {
@@ -73,6 +73,7 @@ resource "aws_lb_listener" "https_alb_listener" {
 }
 
 resource "aws_security_group" "port80_lb_security_group" {
+  count       = var.alb ? 1 : 0
   name        = "nerves-hub-${terraform.workspace}-api-alb-port80"
   description = "nerves-hub ${terraform.workspace} alb port 80"
   vpc_id      = var.vpc.vpc_id
@@ -106,6 +107,7 @@ resource "aws_security_group" "port80_lb_security_group" {
 }
 
 resource "aws_security_group" "port443_lb_security_group" {
+  count       = var.alb ? 1 : 0
   name        = "nerves-hub-${terraform.workspace}-api-alb-port443"
   description = "nerves-hub ${terraform.workspace} alb port 443"
   vpc_id      = var.vpc.vpc_id

--- a/modules/api/alb.tf
+++ b/modules/api/alb.tf
@@ -1,0 +1,118 @@
+# Load Balancer
+resource "aws_lb_target_group" "api_alb_tg" {
+  count                = var.alb ? 1 : 0
+  name                 = "nerves-hub-${terraform.workspace}-api-tg-${random_integer.target_group_id.result}"
+  port                 = 443
+  protocol             = "HTTPS"
+  target_type          = "ip"
+  vpc_id               = var.vpc.vpc_id
+  deregistration_delay = 120
+
+  health_check {
+    interval            = 20
+    timeout             = 10
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = "200-399"
+    protocol            = "HTTPS"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = var.tags
+}
+
+resource "aws_lb" "api_alb" {
+  count              = var.alb ? 1 : 0
+  name               = "nerves-hub-${terraform.workspace}-api-alb"
+  internal           = var.internal_lb
+  load_balancer_type = "application"
+  security_groups    = [var.lb_security_group_id]
+  subnets            = var.vpc.public_subnets
+
+  access_logs {
+    enabled = var.access_logs
+    bucket  = var.access_logs_bucket
+    prefix  = var.access_logs_prefix
+  }
+
+  tags = var.tags
+}
+
+resource "aws_lb_listener" "http_alb_listener" {
+  count             = var.alb ? 1 : 0
+  load_balancer_arn = aws_lb.api_alb[count.index].arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "https_alb_listener" {
+  count             = var.alb ? 1 : 0
+  load_balancer_arn = aws_lb.api_alb[count.index].arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.api_alb_tg[count.index].arn
+  }
+}
+
+# Service
+resource "aws_ecs_service" "api_public_ecs_service" {
+  count   = var.alb ? 1 : 0
+  name    = "nerves-hub-api-public"
+  cluster = var.cluster.arn
+
+  # this needs to be toggled on to update anything in the task besides container (e.g. CPU, memory, etc)
+  # task_definition = "${aws_ecs_task_definition.api_task_definition.family}:${max("${aws_ecs_task_definition.api_task_definition.revision}", "${data.aws_ecs_task_definition.api_task_definition.revision}")}"
+  # task_definition = "${aws_ecs_task_definition.api_task_definition.family}:${aws_ecs_task_definition.api_task_definition.revision}"
+
+  task_definition = aws_ecs_task_definition.api_task_definition.arn
+  desired_count   = var.service_count
+  propagate_tags  = "TASK_DEFINITION"
+
+  deployment_minimum_healthy_percent = "100"
+  deployment_maximum_percent         = "200"
+  launch_type                        = "FARGATE"
+
+  health_check_grace_period_seconds = 300
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.api_alb_tg[count.index].arn
+    container_name   = local.app_name
+    container_port   = 443
+  }
+
+  network_configuration {
+    security_groups = [var.task_security_group_id]
+    subnets         = var.vpc.private_subnets
+  }
+
+  # After the first setup, we want to ignore this so deploys aren't reverted
+  lifecycle {
+    ignore_changes = [task_definition] # create_before_destroy = true
+  }
+
+  tags = var.tags
+
+  depends_on = [
+    aws_iam_role.api_task_role,
+    aws_lb_listener.http_alb_listener,
+    aws_lb_listener.https_alb_listener
+  ]
+}

--- a/modules/api/alb.tf
+++ b/modules/api/alb.tf
@@ -29,7 +29,7 @@ resource "aws_lb" "api_alb" {
   name               = "nerves-hub-${terraform.workspace}-api-alb"
   internal           = var.internal_alb
   load_balancer_type = "application"
-  security_groups    = [aws_security_group.lb_security_group.id]
+  security_groups    = [aws_security_group.port80_lb_security_group.id, aws_security_group.port443_lb_security_group.id]
   subnets            = var.vpc.public_subnets
 
   access_logs {
@@ -72,9 +72,9 @@ resource "aws_lb_listener" "https_alb_listener" {
   }
 }
 
-resource "aws_security_group" "lb_security_group" {
-  name        = "nerves-hub-${terraform.workspace}-api-alb"
-  description = "nerves-hub ${terraform.workspace} alb"
+resource "aws_security_group" "port80_lb_security_group" {
+  name        = "nerves-hub-${terraform.workspace}-api-alb-port80"
+  description = "nerves-hub ${terraform.workspace} alb port 80"
   vpc_id      = var.vpc.vpc_id
 
   ingress {
@@ -85,6 +85,30 @@ resource "aws_security_group" "lb_security_group" {
     cidr_blocks      = var.allow_list_ipv4
     ipv6_cidr_blocks = var.allow_list_ipv6
   }
+
+  egress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+
+    cidr_blocks = [
+      "0.0.0.0/0",
+    ]
+  }
+
+  tags = merge(var.tags, {
+    Name = "nerves-hub-${terraform.workspace}-api alb"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group" "port443_lb_security_group" {
+  name        = "nerves-hub-${terraform.workspace}-api-alb-port443"
+  description = "nerves-hub ${terraform.workspace} alb port 443"
+  vpc_id      = var.vpc.vpc_id
 
   ingress {
     protocol  = "tcp"

--- a/modules/api/alb.tf
+++ b/modules/api/alb.tf
@@ -27,9 +27,9 @@ resource "aws_lb_target_group" "api_alb_tg" {
 resource "aws_lb" "api_alb" {
   count              = var.alb ? 1 : 0
   name               = "nerves-hub-${terraform.workspace}-api-alb"
-  internal           = var.internal_lb
+  internal           = var.internal_alb
   load_balancer_type = "application"
-  security_groups    = [var.lb_security_group_id]
+  security_groups    = [aws_security_group.lb_security_group.id]
   subnets            = var.vpc.public_subnets
 
   access_logs {

--- a/modules/api/output.tf
+++ b/modules/api/output.tf
@@ -1,7 +1,15 @@
 output "lb_zone_id" {
-  value = aws_lb.api_lb.zone_id
+  value = var.nlb ? element(aws_lb.api_lb.*.zone_id, 0) : null
 }
 
 output "lb_dns_name" {
-  value = aws_lb.api_lb.dns_name
+  value = var.nlb ? element(aws_lb.api_lb.*.dns_name, 0) : null
+}
+
+output "alb_zone_id" {
+  value = var.alb ? element(aws_lb.api_alb.*.zone_id, 0) : null
+}
+
+output "alb_dns_name" {
+  value = var.alb ? element(aws_lb.api_alb.*.dns_name, 0) : null
 }

--- a/modules/api/variables.tf
+++ b/modules/api/variables.tf
@@ -18,6 +18,18 @@ variable "smtp_username" {}
 variable "smtp_password" {}
 variable "service_count" {}
 variable "task_execution_role" {}
+variable "alb" {
+  default = false
+}
+variable "nlb" {
+  default = true
+}
+variable "certificate_arn" {
+  default = ""
+}
+variable "lb_security_group_id" {
+  default = ""
+}
 variable "from_email" {
   default = "no-reply@nerves-hub.org"
 }

--- a/modules/api/variables.tf
+++ b/modules/api/variables.tf
@@ -33,9 +33,6 @@ variable "nlb" {
 variable "certificate_arn" {
   default = ""
 }
-variable "lb_security_group_id" {
-  default = ""
-}
 variable "from_email" {
   default = "no-reply@nerves-hub.org"
 }
@@ -50,6 +47,10 @@ variable "access_logs_prefix" {
 }
 variable "internal_lb" {
   description = "Whether or not the load balancer is internal"
+  default     = false
+}
+variable "internal_alb" {
+  description = "Whether or not the application load balancer is internal"
   default     = false
 }
 variable "tags" {

--- a/modules/api/variables.tf
+++ b/modules/api/variables.tf
@@ -18,6 +18,12 @@ variable "smtp_username" {}
 variable "smtp_password" {}
 variable "service_count" {}
 variable "task_execution_role" {}
+variable "allow_list_ipv4" {
+  default = []
+}
+variable "allow_list_ipv6" {
+  default = []
+}
 variable "alb" {
   default = false
 }

--- a/modules/route53/main.tf
+++ b/modules/route53/main.tf
@@ -22,8 +22,8 @@ resource "aws_route53_record" "api_dns_record" {
   type    = "A"
 
   alias {
-    name                   = var.api_lb.lb_dns_name
-    zone_id                = var.api_lb.lb_zone_id
+    name                   = var.is_api_alb ? var.api_lb.alb_dns_name : var.api_lb.lb_dns_name
+    zone_id                = var.is_api_alb ? var.api_lb.alb_zone_id : var.api_lb.lb_zone_id
     evaluate_target_health = false
   }
 }

--- a/modules/route53/variables.tf
+++ b/modules/route53/variables.tf
@@ -5,6 +5,9 @@ variable "api_dns_record_name" {}
 variable "device_dns_record_name" {}
 variable "www_dns_record_name" {}
 variable "dns_zone" {}
+variable "is_api_alb" {
+  default = false
+}
 
 variable "tags" {
   description = "A mapping of tags to assign to the resources"

--- a/modules/route53/variables.tf
+++ b/modules/route53/variables.tf
@@ -6,7 +6,8 @@ variable "device_dns_record_name" {}
 variable "www_dns_record_name" {}
 variable "dns_zone" {}
 variable "is_api_alb" {
-  default = false
+  description = "Whether or not the api has an application load balancer"
+  default     = false
 }
 
 variable "tags" {


### PR DESCRIPTION
## Description 

Adding an option to use a public facing ALB instead of a private NLB. 

Works with existing infrastructure without changes unless making use of `var.alb` boolean for the api module and `is_api_alb` for the route53 module. 

This will help with cutting over to the alb (keeping NLB in place until cutovers are done) and then removing the nlb after as well. 

Other app related changes may be required but is outside the scope of this PR. This is just to provide the option for the infrastructure. 

Tested in dev. 
