### PR TITLE
Separate service count for alb

### DIFF
--- a/modules/api/alb.tf
+++ b/modules/api/alb.tf
@@ -151,7 +151,7 @@ resource "aws_ecs_service" "api_public_ecs_service" {
   # task_definition = "${aws_ecs_task_definition.api_task_definition.family}:${aws_ecs_task_definition.api_task_definition.revision}"
 
   task_definition = aws_ecs_task_definition.api_task_definition.arn
-  desired_count   = var.service_count
+  desired_count   = var.api_public_service_count
   propagate_tags  = "TASK_DEFINITION"
 
   deployment_minimum_healthy_percent = "100"

--- a/modules/api/variables.tf
+++ b/modules/api/variables.tf
@@ -17,6 +17,7 @@ variable "secret_key_base" {}
 variable "smtp_username" {}
 variable "smtp_password" {}
 variable "service_count" {}
+variable "api_public_service_count" {}
 variable "task_execution_role" {}
 variable "allow_list_ipv4" {
   default = []

--- a/modules/api/variables.tf
+++ b/modules/api/variables.tf
@@ -17,7 +17,9 @@ variable "secret_key_base" {}
 variable "smtp_username" {}
 variable "smtp_password" {}
 variable "service_count" {}
-variable "api_public_service_count" {}
+variable "api_public_service_count" {
+  default = 0
+}
 variable "task_execution_role" {}
 variable "allow_list_ipv4" {
   default = []


### PR DESCRIPTION
## Description 

I think this might be helpful to make their ecs task counts different for cutover scenarios (ie cutover from nlb to alb). 

Related to https://github.com/smartrent/nerves-hub-terraform/pull/22. Forgot to put that in there. 
