### PR TITLE
TECH-1560: Datadog Agent added to Device Module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.0.1
+  hooks:
+    # Security
+    - id: detect-aws-credentials
+      args: ['--allow-missing-credentials']
+    - id: detect-private-key
+
+- repo: https://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.60.0
+  hooks:
+    # Terraform
+    - id: terraform_docs
+      args:
+        - --hook-config=--add-to-existing-file=true
+        - --hook-config=--create-file-if-not-exist=true
+    - id: terraform_providers_lock
+      args:
+          - --args=-platform=darwin_amd64
+          - --args=-platform=darwin_arm64
+          - --args=-platform=linux_amd64

--- a/.terraform-docs.yaml
+++ b/.terraform-docs.yaml
@@ -1,0 +1,45 @@
+formatter: "markdown" # this is required
+
+version: "v0.16.0"
+
+header-from: main.tf
+footer-from: ""
+
+recursive:
+  enabled: true
+  path: modules
+
+sections:
+  hide: []
+  show: []
+
+  hide-all: false # deprecated in v0.13.0, removed in v0.15.0
+  show-all: true  # deprecated in v0.13.0, removed in v0.15.0
+
+content: ""
+
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+sort:
+  enabled: true
+  by: name
+
+settings:
+  anchor: true
+  color: true
+  default: true
+  description: true
+  escape: true
+  hide-empty: false
+  html: true
+  indent: 2
+  lockfile: true
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,4 @@
+terraform 0.12.29
+tflint 0.16.2
+terraform-docs v0.16.0
+pre-commit 2.16.0

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,99 @@
+# app
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 2.20 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 2.1 |
+| <a name="requirement_template"></a> [template](#requirement\_template) | ~> 2.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 2.20 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_api"></a> [api](#module\_api) | ../modules/api | n/a |
+| <a name="module_backend"></a> [backend](#module\_backend) | ../modules/backend | n/a |
+| <a name="module_ca"></a> [ca](#module\_ca) | ../modules/ca | n/a |
+| <a name="module_ca_db"></a> [ca\_db](#module\_ca\_db) | ../modules/rds | n/a |
+| <a name="module_device"></a> [device](#module\_device) | ../modules/device | n/a |
+| <a name="module_ecs_cluster"></a> [ecs\_cluster](#module\_ecs\_cluster) | ../modules/ecs/cluster | n/a |
+| <a name="module_route53"></a> [route53](#module\_route53) | ../modules/route53 | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../modules/vpc/ | n/a |
+| <a name="module_web_db"></a> [web\_db](#module\_web\_db) | ../modules/rds | n/a |
+| <a name="module_www"></a> [www](#module\_www) | ../modules/www | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_db_subnet_group.db](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
+| [aws_iam_role.ecs_tasks_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.ecs_tasks_execution_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kms_key.app_enc_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_kms_key.db_enc_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_s3_bucket.web_application_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket.web_firmware_transfer_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_object.web_application_data_firmware](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
+| [aws_s3_bucket_public_access_block.web_application_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_security_group.web_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.web_security_group_all_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.web_security_group_disterl_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.web_security_group_epmd_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.web_security_group_lb_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.web_security_group_ssl_lb_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_service_discovery_private_dns_namespace.local_dns_namespace](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_private_dns_namespace) | resource |
+| [aws_acm_certificate.www_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.ecs_tasks_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_subnet_ids.db_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allow_list_ipv4"></a> [allow\_list\_ipv4](#input\_allow\_list\_ipv4) | The allowed list of IPs for accessing the cluster | `list` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_api_image"></a> [api\_image](#input\_api\_image) | The docker image of the nerves\_hub\_api app | `string` | `"nerveshub/nerves_hub_api:latest"` | no |
+| <a name="input_api_service_desired_count"></a> [api\_service\_desired\_count](#input\_api\_service\_desired\_count) | The number of NervesHubAPI containers to run | `string` | `"1"` | no |
+| <a name="input_billing_enabled"></a> [billing\_enabled](#input\_billing\_enabled) | Enable billing? | `bool` | `false` | no |
+| <a name="input_billing_image"></a> [billing\_image](#input\_billing\_image) | The docker image of the nerves\_hub\_billing app | `string` | `"nerveshub/nerves_hub_billing:latest"` | no |
+| <a name="input_billing_service_desired_count"></a> [billing\_service\_desired\_count](#input\_billing\_service\_desired\_count) | The number of NervesHubBilling containers to run | `string` | `"1"` | no |
+| <a name="input_bucket"></a> [bucket](#input\_bucket) | AWS S3 Bucket name for Terraform state | `any` | n/a | yes |
+| <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | AWS S3 Bucket prefix for application state buckets | `any` | n/a | yes |
+| <a name="input_ca_db_name"></a> [ca\_db\_name](#input\_ca\_db\_name) | The name of the CA database | `string` | `"nerves_hub_ca"` | no |
+| <a name="input_ca_image"></a> [ca\_image](#input\_ca\_image) | The docker image of the nerves\_hub\_ca app | `string` | `"nerveshub/nerves_hub_ca:latest"` | no |
+| <a name="input_ca_service_desired_count"></a> [ca\_service\_desired\_count](#input\_ca\_service\_desired\_count) | The number of NervesHubCA containers to run | `string` | `"1"` | no |
+| <a name="input_db_allocated_storage"></a> [db\_allocated\_storage](#input\_db\_allocated\_storage) | n/a | `number` | `20` | no |
+| <a name="input_db_engine_version"></a> [db\_engine\_version](#input\_db\_engine\_version) | The Engine version of the Postgres database server | `string` | `"11.4"` | no |
+| <a name="input_db_instance_class"></a> [db\_instance\_class](#input\_db\_instance\_class) | The Instance class of the Postgres database server | `string` | `"db.t2.small"` | no |
+| <a name="input_db_password"></a> [db\_password](#input\_db\_password) | Database password | `any` | n/a | yes |
+| <a name="input_db_username"></a> [db\_username](#input\_db\_username) | Database username | `any` | n/a | yes |
+| <a name="input_device_image"></a> [device\_image](#input\_device\_image) | The docker image of the nerves\_hub\_device app | `string` | `"nerveshub/nerves_hub_device:latest"` | no |
+| <a name="input_device_service_desired_count"></a> [device\_service\_desired\_count](#input\_device\_service\_desired\_count) | The number of NervesHubDevice containers to run | `string` | `"1"` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | The domain name | `any` | n/a | yes |
+| <a name="input_dynamodb_table"></a> [dynamodb\_table](#input\_dynamodb\_table) | AWS DynamoDB table for state locking | `any` | n/a | yes |
+| <a name="input_erl_cookie"></a> [erl\_cookie](#input\_erl\_cookie) | The Erlang distribution cookie value | `any` | n/a | yes |
+| <a name="input_key"></a> [key](#input\_key) | Key for Terraform state at S3 bucket | `any` | n/a | yes |
+| <a name="input_log_retention"></a> [log\_retention](#input\_log\_retention) | Cloud watch log retention days | `number` | `90` | no |
+| <a name="input_operators"></a> [operators](#input\_operators) | n/a | `list` | n/a | yes |
+| <a name="input_profile"></a> [profile](#input\_profile) | AWS profile | `any` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `any` | n/a | yes |
+| <a name="input_web_db_name"></a> [web\_db\_name](#input\_web\_db\_name) | The name of the web database | `string` | `"nerves_hub_web"` | no |
+| <a name="input_web_secret_key_base"></a> [web\_secret\_key\_base](#input\_web\_secret\_key\_base) | The secret key base for sessions | `any` | n/a | yes |
+| <a name="input_web_smtp_password"></a> [web\_smtp\_password](#input\_web\_smtp\_password) | The SES SMTP password | `any` | n/a | yes |
+| <a name="input_web_smtp_username"></a> [web\_smtp\_username](#input\_web\_smtp\_username) | The SES SMTP username | `any` | n/a | yes |
+| <a name="input_www_image"></a> [www\_image](#input\_www\_image) | The docker image of the nerves\_hub\_www app | `string` | `"nerveshub/nerves_hub_www:latest"` | no |
+| <a name="input_www_live_view_signing_salt"></a> [www\_live\_view\_signing\_salt](#input\_www\_live\_view\_signing\_salt) | The signing salt to use for Phoenix LiveView | `any` | n/a | yes |
+| <a name="input_www_service_desired_count"></a> [www\_service\_desired\_count](#input\_www\_service\_desired\_count) | The number of NervesHubWWW containers to run | `string` | `"1"` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/base/README.md
+++ b/base/README.md
@@ -1,0 +1,72 @@
+# base
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 2.20 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 2.1 |
+| <a name="requirement_template"></a> [template](#requirement\_template) | ~> 2.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 2.20 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_backend"></a> [backend](#module\_backend) | ../modules/backend | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allow_list_ipv4"></a> [allow\_list\_ipv4](#input\_allow\_list\_ipv4) | The allowed list of IPs for accessing the cluster | `list` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_api_image"></a> [api\_image](#input\_api\_image) | The docker image of the nerves\_hub\_api app | `string` | `"nerveshub/nerves_hub_api:latest"` | no |
+| <a name="input_api_service_desired_count"></a> [api\_service\_desired\_count](#input\_api\_service\_desired\_count) | The number of NervesHubAPI containers to run | `string` | `"1"` | no |
+| <a name="input_billing_enabled"></a> [billing\_enabled](#input\_billing\_enabled) | Enable billing? | `bool` | `false` | no |
+| <a name="input_billing_image"></a> [billing\_image](#input\_billing\_image) | The docker image of the nerves\_hub\_billing app | `string` | `"nerveshub/nerves_hub_billing:latest"` | no |
+| <a name="input_billing_service_desired_count"></a> [billing\_service\_desired\_count](#input\_billing\_service\_desired\_count) | The number of NervesHubBilling containers to run | `string` | `"1"` | no |
+| <a name="input_bucket"></a> [bucket](#input\_bucket) | AWS S3 Bucket name for Terraform state | `any` | n/a | yes |
+| <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | AWS S3 Bucket prefix for application state buckets | `any` | n/a | yes |
+| <a name="input_ca_db_name"></a> [ca\_db\_name](#input\_ca\_db\_name) | The name of the CA database | `string` | `"nerves_hub_ca"` | no |
+| <a name="input_ca_image"></a> [ca\_image](#input\_ca\_image) | The docker image of the nerves\_hub\_ca app | `string` | `"nerveshub/nerves_hub_ca:latest"` | no |
+| <a name="input_ca_service_desired_count"></a> [ca\_service\_desired\_count](#input\_ca\_service\_desired\_count) | The number of NervesHubCA containers to run | `string` | `"1"` | no |
+| <a name="input_db_allocated_storage"></a> [db\_allocated\_storage](#input\_db\_allocated\_storage) | n/a | `number` | `20` | no |
+| <a name="input_db_engine_version"></a> [db\_engine\_version](#input\_db\_engine\_version) | The Engine version of the Postgres database server | `string` | `"11.4"` | no |
+| <a name="input_db_instance_class"></a> [db\_instance\_class](#input\_db\_instance\_class) | The Instance class of the Postgres database server | `string` | `"db.t2.small"` | no |
+| <a name="input_db_password"></a> [db\_password](#input\_db\_password) | Database password | `any` | n/a | yes |
+| <a name="input_db_username"></a> [db\_username](#input\_db\_username) | Database username | `any` | n/a | yes |
+| <a name="input_device_image"></a> [device\_image](#input\_device\_image) | The docker image of the nerves\_hub\_device app | `string` | `"nerveshub/nerves_hub_device:latest"` | no |
+| <a name="input_device_service_desired_count"></a> [device\_service\_desired\_count](#input\_device\_service\_desired\_count) | The number of NervesHubDevice containers to run | `string` | `"1"` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | The domain name | `any` | n/a | yes |
+| <a name="input_dynamodb_table"></a> [dynamodb\_table](#input\_dynamodb\_table) | AWS DynamoDB table for state locking | `any` | n/a | yes |
+| <a name="input_erl_cookie"></a> [erl\_cookie](#input\_erl\_cookie) | The Erlang distribution cookie value | `any` | n/a | yes |
+| <a name="input_key"></a> [key](#input\_key) | Key for Terraform state at S3 bucket | `any` | n/a | yes |
+| <a name="input_log_retention"></a> [log\_retention](#input\_log\_retention) | Cloud watch log retention days | `number` | `90` | no |
+| <a name="input_operators"></a> [operators](#input\_operators) | n/a | `list` | n/a | yes |
+| <a name="input_profile"></a> [profile](#input\_profile) | AWS profile | `any` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `any` | n/a | yes |
+| <a name="input_web_db_name"></a> [web\_db\_name](#input\_web\_db\_name) | The name of the web database | `string` | `"nerves_hub_web"` | no |
+| <a name="input_web_secret_key_base"></a> [web\_secret\_key\_base](#input\_web\_secret\_key\_base) | The secret key base for sessions | `any` | n/a | yes |
+| <a name="input_web_smtp_password"></a> [web\_smtp\_password](#input\_web\_smtp\_password) | The SES SMTP password | `any` | n/a | yes |
+| <a name="input_web_smtp_username"></a> [web\_smtp\_username](#input\_web\_smtp\_username) | The SES SMTP username | `any` | n/a | yes |
+| <a name="input_www_image"></a> [www\_image](#input\_www\_image) | The docker image of the nerves\_hub\_www app | `string` | `"nerveshub/nerves_hub_www:latest"` | no |
+| <a name="input_www_live_view_signing_salt"></a> [www\_live\_view\_signing\_salt](#input\_www\_live\_view\_signing\_salt) | The signing salt to use for Phoenix LiveView | `any` | n/a | yes |
+| <a name="input_www_service_desired_count"></a> [www\_service\_desired\_count](#input\_www\_service\_desired\_count) | The number of NervesHubWWW containers to run | `string` | `"1"` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/billing/README.md
+++ b/billing/README.md
@@ -1,0 +1,101 @@
+# billing
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 2.20 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 2.1 |
+| <a name="requirement_template"></a> [template](#requirement\_template) | ~> 2.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 2.20 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_api"></a> [api](#module\_api) | ../modules/api | n/a |
+| <a name="module_backend"></a> [backend](#module\_backend) | ../modules/backend | n/a |
+| <a name="module_billing"></a> [billing](#module\_billing) | ../modules/billing | n/a |
+| <a name="module_billing_db"></a> [billing\_db](#module\_billing\_db) | ../modules/rds | n/a |
+| <a name="module_ca"></a> [ca](#module\_ca) | ../modules/ca | n/a |
+| <a name="module_ca_db"></a> [ca\_db](#module\_ca\_db) | ../modules/rds | n/a |
+| <a name="module_device"></a> [device](#module\_device) | ../modules/device | n/a |
+| <a name="module_ecs_cluster"></a> [ecs\_cluster](#module\_ecs\_cluster) | ../modules/ecs/cluster | n/a |
+| <a name="module_route53"></a> [route53](#module\_route53) | ../modules/route53 | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../modules/vpc/ | n/a |
+| <a name="module_web_db"></a> [web\_db](#module\_web\_db) | ../modules/rds | n/a |
+| <a name="module_www"></a> [www](#module\_www) | ../modules/www | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_db_subnet_group.db](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
+| [aws_iam_role.ecs_tasks_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.ecs_tasks_execution_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kms_key.app_enc_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_kms_key.db_enc_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_s3_bucket.web_application_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket.web_firmware_transfer_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_object.web_application_data_firmware](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
+| [aws_s3_bucket_public_access_block.web_application_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_security_group.web_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.web_security_group_all_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.web_security_group_disterl_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.web_security_group_epmd_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.web_security_group_lb_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.web_security_group_ssl_lb_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_service_discovery_private_dns_namespace.local_dns_namespace](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_private_dns_namespace) | resource |
+| [aws_acm_certificate.www_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.ecs_tasks_execution_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_subnet_ids.db_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allow_list_ipv4"></a> [allow\_list\_ipv4](#input\_allow\_list\_ipv4) | The allowed list of IPs for accessing the cluster | `list` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_api_image"></a> [api\_image](#input\_api\_image) | The docker image of the nerves\_hub\_api app | `string` | `"nerveshub/nerves_hub_api:latest"` | no |
+| <a name="input_api_service_desired_count"></a> [api\_service\_desired\_count](#input\_api\_service\_desired\_count) | The number of NervesHubAPI containers to run | `string` | `"1"` | no |
+| <a name="input_billing_enabled"></a> [billing\_enabled](#input\_billing\_enabled) | Enable billing? | `bool` | `false` | no |
+| <a name="input_billing_image"></a> [billing\_image](#input\_billing\_image) | The docker image of the nerves\_hub\_billing app | `string` | `"nerveshub/nerves_hub_billing:latest"` | no |
+| <a name="input_billing_service_desired_count"></a> [billing\_service\_desired\_count](#input\_billing\_service\_desired\_count) | The number of NervesHubBilling containers to run | `string` | `"1"` | no |
+| <a name="input_bucket"></a> [bucket](#input\_bucket) | AWS S3 Bucket name for Terraform state | `any` | n/a | yes |
+| <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | AWS S3 Bucket prefix for application state buckets | `any` | n/a | yes |
+| <a name="input_ca_db_name"></a> [ca\_db\_name](#input\_ca\_db\_name) | The name of the CA database | `string` | `"nerves_hub_ca"` | no |
+| <a name="input_ca_image"></a> [ca\_image](#input\_ca\_image) | The docker image of the nerves\_hub\_ca app | `string` | `"nerveshub/nerves_hub_ca:latest"` | no |
+| <a name="input_ca_service_desired_count"></a> [ca\_service\_desired\_count](#input\_ca\_service\_desired\_count) | The number of NervesHubCA containers to run | `string` | `"1"` | no |
+| <a name="input_db_allocated_storage"></a> [db\_allocated\_storage](#input\_db\_allocated\_storage) | n/a | `number` | `20` | no |
+| <a name="input_db_engine_version"></a> [db\_engine\_version](#input\_db\_engine\_version) | The Engine version of the Postgres database server | `string` | `"11.4"` | no |
+| <a name="input_db_instance_class"></a> [db\_instance\_class](#input\_db\_instance\_class) | The Instance class of the Postgres database server | `string` | `"db.t2.small"` | no |
+| <a name="input_db_password"></a> [db\_password](#input\_db\_password) | Database password | `any` | n/a | yes |
+| <a name="input_db_username"></a> [db\_username](#input\_db\_username) | Database username | `any` | n/a | yes |
+| <a name="input_device_image"></a> [device\_image](#input\_device\_image) | The docker image of the nerves\_hub\_device app | `string` | `"nerveshub/nerves_hub_device:latest"` | no |
+| <a name="input_device_service_desired_count"></a> [device\_service\_desired\_count](#input\_device\_service\_desired\_count) | The number of NervesHubDevice containers to run | `string` | `"1"` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | The domain name | `any` | n/a | yes |
+| <a name="input_dynamodb_table"></a> [dynamodb\_table](#input\_dynamodb\_table) | AWS DynamoDB table for state locking | `any` | n/a | yes |
+| <a name="input_erl_cookie"></a> [erl\_cookie](#input\_erl\_cookie) | The Erlang distribution cookie value | `any` | n/a | yes |
+| <a name="input_key"></a> [key](#input\_key) | Key for Terraform state at S3 bucket | `any` | n/a | yes |
+| <a name="input_log_retention"></a> [log\_retention](#input\_log\_retention) | Cloud watch log retention days | `number` | `90` | no |
+| <a name="input_operators"></a> [operators](#input\_operators) | n/a | `list` | n/a | yes |
+| <a name="input_profile"></a> [profile](#input\_profile) | AWS profile | `any` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `any` | n/a | yes |
+| <a name="input_web_db_name"></a> [web\_db\_name](#input\_web\_db\_name) | The name of the web database | `string` | `"nerves_hub_web"` | no |
+| <a name="input_web_secret_key_base"></a> [web\_secret\_key\_base](#input\_web\_secret\_key\_base) | The secret key base for sessions | `any` | n/a | yes |
+| <a name="input_web_smtp_password"></a> [web\_smtp\_password](#input\_web\_smtp\_password) | The SES SMTP password | `any` | n/a | yes |
+| <a name="input_web_smtp_username"></a> [web\_smtp\_username](#input\_web\_smtp\_username) | The SES SMTP username | `any` | n/a | yes |
+| <a name="input_www_image"></a> [www\_image](#input\_www\_image) | The docker image of the nerves\_hub\_www app | `string` | `"nerveshub/nerves_hub_www:latest"` | no |
+| <a name="input_www_live_view_signing_salt"></a> [www\_live\_view\_signing\_salt](#input\_www\_live\_view\_signing\_salt) | The signing salt to use for Phoenix LiveView | `any` | n/a | yes |
+| <a name="input_www_service_desired_count"></a> [www\_service\_desired\_count](#input\_www\_service\_desired\_count) | The number of NervesHubWWW containers to run | `string` | `"1"` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/common/README.md
+++ b/common/README.md
@@ -1,0 +1,27 @@
+# common
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -1,0 +1,104 @@
+# api
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ecs_service.api_ecs_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_service.api_public_ecs_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.api_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_iam_policy.api_task_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.api_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.api_role_policy_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lb.api_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb.api_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.api_lb_listener](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.http_alb_listener](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.https_alb_listener](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.api_alb_tg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group.api_lb_tg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_security_group.port443_lb_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.port80_lb_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_ssm_parameter.nerves_hub_api_ssm_app_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_api_ssm_aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_api_ssm_ca_host](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_api_ssm_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_api_ssm_host](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_api_ssm_port](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_api_ssm_s3_bucket_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_api_ssm_s3_log_bucket_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_api_ssm_s3_ssl_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_api_ssm_secret_db_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_api_ssm_secret_erl_cookie](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_api_ssm_secret_secret_key_base](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_api_ssm_secret_smtp_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_api_ssm_ses_port](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_api_ssm_ses_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_api_ssm_smtp_username](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ses_from_email](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [random_integer.target_group_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
+| [aws_iam_policy_document.api_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_access_logs"></a> [access\_logs](#input\_access\_logs) | n/a | `bool` | `false` | no |
+| <a name="input_access_logs_bucket"></a> [access\_logs\_bucket](#input\_access\_logs\_bucket) | n/a | `string` | `""` | no |
+| <a name="input_access_logs_prefix"></a> [access\_logs\_prefix](#input\_access\_logs\_prefix) | n/a | `string` | `"nerves-hub-api-nlb"` | no |
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | n/a | `any` | n/a | yes |
+| <a name="input_alb"></a> [alb](#input\_alb) | n/a | `bool` | `false` | no |
+| <a name="input_allow_list_ipv4"></a> [allow\_list\_ipv4](#input\_allow\_list\_ipv4) | n/a | `list` | `[]` | no |
+| <a name="input_allow_list_ipv6"></a> [allow\_list\_ipv6](#input\_allow\_list\_ipv6) | n/a | `list` | `[]` | no |
+| <a name="input_api_public_service_count"></a> [api\_public\_service\_count](#input\_api\_public\_service\_count) | n/a | `number` | `0` | no |
+| <a name="input_app_bucket"></a> [app\_bucket](#input\_app\_bucket) | n/a | `any` | n/a | yes |
+| <a name="input_ca_bucket"></a> [ca\_bucket](#input\_ca\_bucket) | n/a | `any` | n/a | yes |
+| <a name="input_ca_host"></a> [ca\_host](#input\_ca\_host) | n/a | `any` | n/a | yes |
+| <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | n/a | `string` | `""` | no |
+| <a name="input_cluster"></a> [cluster](#input\_cluster) | n/a | `any` | n/a | yes |
+| <a name="input_db"></a> [db](#input\_db) | n/a | `any` | n/a | yes |
+| <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | n/a | `any` | n/a | yes |
+| <a name="input_erl_cookie"></a> [erl\_cookie](#input\_erl\_cookie) | n/a | `any` | n/a | yes |
+| <a name="input_from_email"></a> [from\_email](#input\_from\_email) | n/a | `string` | `"no-reply@nerves-hub.org"` | no |
+| <a name="input_host_name"></a> [host\_name](#input\_host\_name) | n/a | `any` | n/a | yes |
+| <a name="input_internal_alb"></a> [internal\_alb](#input\_internal\_alb) | Whether or not the application load balancer is internal | `bool` | `false` | no |
+| <a name="input_internal_lb"></a> [internal\_lb](#input\_internal\_lb) | Whether or not the load balancer is internal | `bool` | `false` | no |
+| <a name="input_kms_key"></a> [kms\_key](#input\_kms\_key) | n/a | `any` | n/a | yes |
+| <a name="input_log_bucket"></a> [log\_bucket](#input\_log\_bucket) | n/a | `any` | n/a | yes |
+| <a name="input_log_group"></a> [log\_group](#input\_log\_group) | n/a | `any` | n/a | yes |
+| <a name="input_nlb"></a> [nlb](#input\_nlb) | n/a | `bool` | `true` | no |
+| <a name="input_region"></a> [region](#input\_region) | n/a | `any` | n/a | yes |
+| <a name="input_secret_key_base"></a> [secret\_key\_base](#input\_secret\_key\_base) | n/a | `any` | n/a | yes |
+| <a name="input_service_count"></a> [service\_count](#input\_service\_count) | n/a | `any` | n/a | yes |
+| <a name="input_smtp_password"></a> [smtp\_password](#input\_smtp\_password) | n/a | `any` | n/a | yes |
+| <a name="input_smtp_username"></a> [smtp\_username](#input\_smtp\_username) | n/a | `any` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources | `map(string)` | <pre>{<br>  "terraform": true<br>}</pre> | no |
+| <a name="input_task_execution_role"></a> [task\_execution\_role](#input\_task\_execution\_role) | n/a | `any` | n/a | yes |
+| <a name="input_task_security_group_id"></a> [task\_security\_group\_id](#input\_task\_security\_group\_id) | n/a | `any` | n/a | yes |
+| <a name="input_vpc"></a> [vpc](#input\_vpc) | n/a | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_alb_dns_name"></a> [alb\_dns\_name](#output\_alb\_dns\_name) | n/a |
+| <a name="output_alb_zone_id"></a> [alb\_zone\_id](#output\_alb\_zone\_id) | n/a |
+| <a name="output_lb_dns_name"></a> [lb\_dns\_name](#output\_lb\_dns\_name) | n/a |
+| <a name="output_lb_zone_id"></a> [lb\_zone\_id](#output\_lb\_zone\_id) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -85,7 +85,7 @@ No modules.
 | <a name="input_nlb"></a> [nlb](#input\_nlb) | n/a | `bool` | `true` | no |
 | <a name="input_region"></a> [region](#input\_region) | n/a | `any` | n/a | yes |
 | <a name="input_secret_key_base"></a> [secret\_key\_base](#input\_secret\_key\_base) | n/a | `any` | n/a | yes |
-| <a name="input_service_count"></a> [service\_count](#input\_service\_count) | n/a | `any` | n/a | yes |
+| <a name="input_service_count"></a> [service\_count](#input\_service\_count) | n/a | `number` | `0` | no |
 | <a name="input_smtp_password"></a> [smtp\_password](#input\_smtp\_password) | n/a | `any` | n/a | yes |
 | <a name="input_smtp_username"></a> [smtp\_username](#input\_smtp\_username) | n/a | `any` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources | `map(string)` | <pre>{<br>  "terraform": true<br>}</pre> | no |

--- a/modules/api/variables.tf
+++ b/modules/api/variables.tf
@@ -16,7 +16,9 @@ variable "cluster" {}
 variable "secret_key_base" {}
 variable "smtp_username" {}
 variable "smtp_password" {}
-variable "service_count" {}
+variable "service_count" {
+  default = 0
+}
 variable "api_public_service_count" {
   default = 0
 }

--- a/modules/backend/README.md
+++ b/modules/backend/README.md
@@ -1,0 +1,47 @@
+# backend
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_template"></a> [template](#provider\_template) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_dynamodb_table.terraform_statelock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_kms_key.tf_enc_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_s3_bucket.terraform_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_policy.terraform_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_iam_user.operators](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_user) | data source |
+| [template_file.operator_arn](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
+| [template_file.terraform_state_policy](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_bootstrap"></a> [bootstrap](#input\_bootstrap) | Whether bootstrap basic infra or not | `number` | `0` | no |
+| <a name="input_bucket"></a> [bucket](#input\_bucket) | n/a | `any` | n/a | yes |
+| <a name="input_dynamodb_table"></a> [dynamodb\_table](#input\_dynamodb\_table) | n/a | `any` | n/a | yes |
+| <a name="input_key"></a> [key](#input\_key) | n/a | `any` | n/a | yes |
+| <a name="input_operators"></a> [operators](#input\_operators) | n/a | `list` | n/a | yes |
+| <a name="input_s3_access_log_bucket"></a> [s3\_access\_log\_bucket](#input\_s3\_access\_log\_bucket) | What bucket to write access logs to | `string` | `""` | no |
+| <a name="input_s3_prefix"></a> [s3\_prefix](#input\_s3\_prefix) | S3 bucket name prefix | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources | `map(string)` | <pre>{<br>  "terraform": true<br>}</pre> | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/billing/README.md
+++ b/modules/billing/README.md
@@ -1,0 +1,67 @@
+# billing
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ecs_service.billing_ecs_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.billing_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_iam_policy.billing_task_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.billing_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.billing_role_policy_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_s3_bucket_object.web_application_data_billing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
+| [aws_security_group.billing_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.billing_security_group_all_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.billing_security_group_web_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.db_security_group_billing_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.db_security_group_billing_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_service_discovery_service.billing_service_discovery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_service) | resource |
+| [aws_ssm_parameter.nerves_hub_billing_ssm_app_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_billing_ssm_host](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_billing_ssm_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_billing_ssm_secret_db_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_billing_ssm_secret_erl_cookie](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_iam_policy_document.billing_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | n/a | `any` | n/a | yes |
+| <a name="input_app_bucket"></a> [app\_bucket](#input\_app\_bucket) | n/a | `any` | n/a | yes |
+| <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | n/a | `any` | n/a | yes |
+| <a name="input_ca_bucket"></a> [ca\_bucket](#input\_ca\_bucket) | n/a | `any` | n/a | yes |
+| <a name="input_cluster"></a> [cluster](#input\_cluster) | n/a | `any` | n/a | yes |
+| <a name="input_db"></a> [db](#input\_db) | n/a | `any` | n/a | yes |
+| <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | n/a | `any` | n/a | yes |
+| <a name="input_domain"></a> [domain](#input\_domain) | n/a | `any` | n/a | yes |
+| <a name="input_erl_cookie"></a> [erl\_cookie](#input\_erl\_cookie) | n/a | `any` | n/a | yes |
+| <a name="input_kms_key"></a> [kms\_key](#input\_kms\_key) | n/a | `any` | n/a | yes |
+| <a name="input_local_dns_namespace"></a> [local\_dns\_namespace](#input\_local\_dns\_namespace) | n/a | `any` | n/a | yes |
+| <a name="input_log_group"></a> [log\_group](#input\_log\_group) | n/a | `any` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | n/a | `any` | n/a | yes |
+| <a name="input_service_count"></a> [service\_count](#input\_service\_count) | n/a | `any` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources | `map(string)` | <pre>{<br>  "terraform": true<br>}</pre> | no |
+| <a name="input_task_execution_role"></a> [task\_execution\_role](#input\_task\_execution\_role) | n/a | `any` | n/a | yes |
+| <a name="input_vpc"></a> [vpc](#input\_vpc) | n/a | `any` | n/a | yes |
+| <a name="input_web_security_group"></a> [web\_security\_group](#input\_web\_security\_group) | n/a | `any` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ca/README.md
+++ b/modules/ca/README.md
@@ -1,0 +1,78 @@
+# ca
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ecs_service.ca_ecs_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.ca_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_iam_policy.ca_task_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.ca_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.ca_role_policy_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_s3_bucket.ca_application_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_object.ca_application_data_ssl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
+| [aws_s3_bucket_public_access_block.ca_application_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_security_group.ca_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.ca_security_group_all_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ca_security_group_web_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_service_discovery_service.ca_service_discovery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_service) | resource |
+| [aws_ssm_parameter.nerves_hub_ca_ssm_app_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_ca_ssm_host](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_ca_ssm_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_ca_ssm_secret_db_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_ca_ssm_secret_erl_cookie](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [null_resource.sync_ca_application_data_ssl](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [aws_iam_policy_document.ca_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | n/a | `any` | n/a | yes |
+| <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | n/a | `any` | n/a | yes |
+| <a name="input_cluster"></a> [cluster](#input\_cluster) | n/a | `any` | n/a | yes |
+| <a name="input_db"></a> [db](#input\_db) | n/a | `any` | n/a | yes |
+| <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | n/a | `any` | n/a | yes |
+| <a name="input_erl_cookie"></a> [erl\_cookie](#input\_erl\_cookie) | n/a | `any` | n/a | yes |
+| <a name="input_host_name"></a> [host\_name](#input\_host\_name) | n/a | `any` | n/a | yes |
+| <a name="input_kms_key"></a> [kms\_key](#input\_kms\_key) | n/a | `any` | n/a | yes |
+| <a name="input_local_dns_namespace"></a> [local\_dns\_namespace](#input\_local\_dns\_namespace) | n/a | `any` | n/a | yes |
+| <a name="input_log_group"></a> [log\_group](#input\_log\_group) | n/a | `any` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | n/a | `any` | n/a | yes |
+| <a name="input_s3_access_log_bucket"></a> [s3\_access\_log\_bucket](#input\_s3\_access\_log\_bucket) | What bucket to write access logs to | `string` | `""` | no |
+| <a name="input_s3_prefix"></a> [s3\_prefix](#input\_s3\_prefix) | S3 bucket name prefix | `string` | `""` | no |
+| <a name="input_s3_versioning"></a> [s3\_versioning](#input\_s3\_versioning) | n/a | `bool` | `false` | no |
+| <a name="input_service_count"></a> [service\_count](#input\_service\_count) | n/a | `any` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources | `map(string)` | <pre>{<br>  "terraform": true<br>}</pre> | no |
+| <a name="input_task_execution_role"></a> [task\_execution\_role](#input\_task\_execution\_role) | n/a | `any` | n/a | yes |
+| <a name="input_vpc"></a> [vpc](#input\_vpc) | n/a | `any` | n/a | yes |
+| <a name="input_web_security_group"></a> [web\_security\_group](#input\_web\_security\_group) | n/a | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_bucket"></a> [bucket](#output\_bucket) | n/a |
+| <a name="output_bucket_arn"></a> [bucket\_arn](#output\_bucket\_arn) | n/a |
+| <a name="output_bucket_id"></a> [bucket\_id](#output\_bucket\_id) | n/a |
+| <a name="output_host"></a> [host](#output\_host) | n/a |
+| <a name="output_object_key"></a> [object\_key](#output\_object\_key) | n/a |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | n/a |
+| <a name="output_service_discovery_arn"></a> [service\_discovery\_arn](#output\_service\_discovery\_arn) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/device/README.md
+++ b/modules/device/README.md
@@ -14,7 +14,9 @@ No requirements.
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_logging_configs"></a> [logging\_configs](#module\_logging\_configs) | ../logging_configs | n/a |
 
 ## Resources
 
@@ -59,8 +61,11 @@ No modules.
 | <a name="input_ca_bucket"></a> [ca\_bucket](#input\_ca\_bucket) | n/a | `any` | n/a | yes |
 | <a name="input_ca_host"></a> [ca\_host](#input\_ca\_host) | n/a | `any` | n/a | yes |
 | <a name="input_cluster"></a> [cluster](#input\_cluster) | n/a | `any` | n/a | yes |
+| <a name="input_datadog_image"></a> [datadog\_image](#input\_datadog\_image) | Datadog container image | `string` | n/a | yes |
+| <a name="input_datadog_key_arn"></a> [datadog\_key\_arn](#input\_datadog\_key\_arn) | Datadog Key | `string` | n/a | yes |
 | <a name="input_db"></a> [db](#input\_db) | n/a | `any` | n/a | yes |
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | n/a | `any` | n/a | yes |
+| <a name="input_docker_image_tag"></a> [docker\_image\_tag](#input\_docker\_image\_tag) | Docker Image tag for Device Application | `string` | n/a | yes |
 | <a name="input_erl_cookie"></a> [erl\_cookie](#input\_erl\_cookie) | n/a | `any` | n/a | yes |
 | <a name="input_from_email"></a> [from\_email](#input\_from\_email) | n/a | `string` | `"no-reply@nerves-hub.org"` | no |
 | <a name="input_host_name"></a> [host\_name](#input\_host\_name) | n/a | `any` | n/a | yes |

--- a/modules/device/README.md
+++ b/modules/device/README.md
@@ -1,0 +1,86 @@
+# device
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ecs_service.device_ecs_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.device_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_iam_policy.device_task_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.device_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.device_role_policy_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lb.device_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.device_lb_listener](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.device_lb_tg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_ssm_parameter.nerves_hub_device_ssm_app_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_device_ssm_aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_device_ssm_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_device_ssm_host](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_device_ssm_port](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_device_ssm_s3_bucket_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_device_ssm_s3_log_bucket_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_device_ssm_s3_ssl_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_device_ssm_secret_db_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_device_ssm_secret_erl_cookie](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_device_ssm_secret_secret_key_base](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_device_ssm_secret_smtp_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_device_ssm_ses_port](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_device_ssm_ses_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_device_ssm_smtp_username](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ses_from_email](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [random_integer.target_group_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
+| [aws_iam_policy_document.device_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_access_logs"></a> [access\_logs](#input\_access\_logs) | n/a | `bool` | `false` | no |
+| <a name="input_access_logs_bucket"></a> [access\_logs\_bucket](#input\_access\_logs\_bucket) | n/a | `string` | `""` | no |
+| <a name="input_access_logs_prefix"></a> [access\_logs\_prefix](#input\_access\_logs\_prefix) | n/a | `string` | `"nerves-hub-device-nlb"` | no |
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | n/a | `any` | n/a | yes |
+| <a name="input_app_bucket"></a> [app\_bucket](#input\_app\_bucket) | n/a | `any` | n/a | yes |
+| <a name="input_ca_bucket"></a> [ca\_bucket](#input\_ca\_bucket) | n/a | `any` | n/a | yes |
+| <a name="input_ca_host"></a> [ca\_host](#input\_ca\_host) | n/a | `any` | n/a | yes |
+| <a name="input_cluster"></a> [cluster](#input\_cluster) | n/a | `any` | n/a | yes |
+| <a name="input_db"></a> [db](#input\_db) | n/a | `any` | n/a | yes |
+| <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | n/a | `any` | n/a | yes |
+| <a name="input_erl_cookie"></a> [erl\_cookie](#input\_erl\_cookie) | n/a | `any` | n/a | yes |
+| <a name="input_from_email"></a> [from\_email](#input\_from\_email) | n/a | `string` | `"no-reply@nerves-hub.org"` | no |
+| <a name="input_host_name"></a> [host\_name](#input\_host\_name) | n/a | `any` | n/a | yes |
+| <a name="input_kms_key"></a> [kms\_key](#input\_kms\_key) | n/a | `any` | n/a | yes |
+| <a name="input_log_bucket"></a> [log\_bucket](#input\_log\_bucket) | n/a | `any` | n/a | yes |
+| <a name="input_log_group"></a> [log\_group](#input\_log\_group) | n/a | `any` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | n/a | `any` | n/a | yes |
+| <a name="input_secret_key_base"></a> [secret\_key\_base](#input\_secret\_key\_base) | n/a | `any` | n/a | yes |
+| <a name="input_service_count"></a> [service\_count](#input\_service\_count) | n/a | `any` | n/a | yes |
+| <a name="input_smtp_password"></a> [smtp\_password](#input\_smtp\_password) | n/a | `any` | n/a | yes |
+| <a name="input_smtp_username"></a> [smtp\_username](#input\_smtp\_username) | n/a | `any` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources | `map(string)` | <pre>{<br>  "terraform": true<br>}</pre> | no |
+| <a name="input_task_execution_role"></a> [task\_execution\_role](#input\_task\_execution\_role) | n/a | `any` | n/a | yes |
+| <a name="input_task_security_group_id"></a> [task\_security\_group\_id](#input\_task\_security\_group\_id) | n/a | `any` | n/a | yes |
+| <a name="input_vpc"></a> [vpc](#input\_vpc) | n/a | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_lb_dns_name"></a> [lb\_dns\_name](#output\_lb\_dns\_name) | n/a |
+| <a name="output_lb_zone_id"></a> [lb\_zone\_id](#output\_lb\_zone\_id) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -5,9 +5,7 @@ locals {
 
   ecs_shared_env_vars = <<EOF
     { "name" : "ENVIRONMENT", "value" : "${terraform.workspace}" },
-    { "name" : "APP_NAME", "value" : "${local.device_app_name}" },
-    { "name" : "HOST", "value" : "${var.host_name}" },
-    { "name" : "CLUSTER", "value" : "${var.cluster.name}" }
+    { "name" : "APP_NAME", "value" : "${local.device_app_name}" }
 EOF
 
 }

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -407,7 +407,7 @@ DEFINITION
 module "logging_configs" {
   source            = "../logging_configs"
   app_name          = local.device_app_name
-  environment_name  = var.environment_name
+  environment_name  = terraform.workspace
   task_name         = local.device_app_name
   datadog_image     = var.datadog_image
   docker_image_tag = var.docker_image_tag

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -371,8 +371,8 @@ resource "aws_ecs_task_definition" "device_task_definition" {
 
   container_definitions = <<DEFINITION
    [
-     ${module.firelens_log_config.fire_lens_container},
-     ${module.firelens_log_config.datadog_container},
+     ${module.logging_configs.fire_lens_container},
+     ${module.logging_configs.datadog_container},
      {
        "portMappings": [
          {
@@ -394,21 +394,21 @@ resource "aws_ecs_task_definition" "device_task_definition" {
        "environment": [
          ${local.ecs_shared_env_vars}
        ],
-     ${module.firelens_log_config.log_configuration}
+     ${module.logging_configs.log_configuration}
      }
    ]
 DEFINITION
 
 
   depends_on = [
-    module.firelens_log_config
+    module.logging_configs
   ]
 
   tags = var.tags
 }
 
-module "firelens_log_config" {
-  source            = "../firelens_log_config"
+module "logging_configs" {
+  source            = "../logging_configs"
   app_name          = local.device_app_name
   environment_name  = var.environment_name
   task_name         = local.device_app_name

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -9,6 +9,7 @@ locals {
     { "name" : "APP_NAME", "value" : "${local.device_app_name}" },
     { "name" : "HOST", "value" : "${var.host_name}" },
     { "name" : "CLUSTER", "value" : "${var.cluster.name}" }
+
 EOF
 
 }
@@ -393,34 +394,11 @@ resource "aws_ecs_task_definition" "device_task_definition" {
        "name": "${local.device_app_name}",
        "environment": [
          ${local.ecs_shared_env_vars}
-       ],
-       "volumesFrom": [],
-       "mountPoints": [],
-       "logConfiguration": {
-         "logDriver": "awsfirelens",
-         "options": {
-            "Name": "datadog",
-            "compress": "gzip",
-            "Host": "http-intake.logs.datadoghq.com",
-            "dd_service": "${local.device_app_name}",
-            "dd_source": "elixir",
-            "dd_message_key": "log",
-            "dd_tags": "env:${var.environment_name},application:${local.device_app_name}-${var.environment_name},version:${var.docker_image}",
-            "TLS": "on",
-            "provider": "ecs"
-          },
-          "secretOptions": [
-            {
-              "name": "apikey",
-              "valueFrom": "${module.firelens_log_config.datadog_key_arn}"
-            }
-          ]
-       }
+       ]
      },
      ${module.firelens_log_config.datadog_container}
    ]
 DEFINITION
-
 
 
 depends_on = [

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -245,7 +245,6 @@ data "aws_iam_policy_document" "device_iam_policy" {
 
     resources = [
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter/${local.device_app_name}/${terraform.workspace}*",
-      var.datadog_key_arn
     ]
   }
 

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -11,108 +11,6 @@ locals {
     { "name" : "CLUSTER", "value" : "${var.cluster.name}" }
 EOF
 
-  fire_lens_container = <<EOF
-  {
-    "essential": true,
-    "image": "906394416424.dkr.ecr.${var.region}.amazonaws.com/aws-for-fluent-bit:stable",
-    "name": "log_router",
-    "cpu": 0,
-    "user": "0",
-    "environment": [],
-    "volumesFrom": [],
-    "portMappings": [],
-    "mountPoints": [],
-    "firelensConfiguration": {
-      "type": "fluentbit",
-      "options": {
-        "enable-ecs-log-metadata": "true"
-      }
-    },
-    "memoryReservation": 50
-  }
-EOF
-
- datadog_ecs_agent_task_def = <<EOF
-{
-  "name": "datadog-agent",
-  "image": "${var.datadog_image}",
-  "essential": false,
-  "memoryReservation": 256,
-  "cpu": 10,
-  "mountPoints": [],
-  "volumesFrom": [],
-  "portMappings": [
-    {
-      "containerPort": 8125,
-      "hostPort": 8125,
-      "protocol": "udp"
-    },
-    {
-      "containerPort": 8126,
-      "hostPort": 8126,
-      "protocol": "tcp"
-    }
-  ],
-  "environment": [
-    {
-      "name": "ECS_FARGATE",
-      "value": "true"
-    },
-    {
-      "name": "DD_LOG_LEVEL",
-      "value": "warn"
-    },
-    {
-      "name": "DD_APM_ENABLED",
-      "value": "true"
-    },
-    {
-      "name": "DD_APM_NON_LOCAL_TRAFFIC",
-      "value": "true"
-    },
-    {
-      "name": "DD_SYSTEM_PROBE_ENABLED",
-      "value": "true"
-    },
-    {
-      "name": "DD_PROCESS_AGENT_ENABLED",
-      "value": "true"
-    },
-    {
-      "name": "DD_HEALTH_PORT",
-      "value": "5555"
-    },
-    {
-      "name": "DD_APM_RECEIVER_PORT",
-      "value": "8126"
-    },
-    {
-      "name": "DD_DOGSTATSD_NON_LOCAL_TRAFFIC",
-      "value": "true"
-    },
-    {
-      "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
-      "value": "true"
-    },
-    {
-      "name": "DD_DOGSTATSD_PORT",
-      "value": "8125"
-    },
-    {
-      "name": "DD_DOCKER_LABELS_AS_TAGS",
-      "value": "${replace(jsonencode(var.tags), "\"", "\\\"")}"
-    }
-  ],
-  "secrets": [
-    {
-      "name": "DD_API_KEY",
-      "valueFrom": "${module.firelens_log_config.datadog_key_arn}"
-    }
-  ],
-  ${module.firelens_log_config.log_configuration}
-}
-EOF
-
 }
 
 resource "random_integer" "target_group_id" {
@@ -474,7 +372,7 @@ resource "aws_ecs_task_definition" "device_task_definition" {
 
   container_definitions = <<DEFINITION
    [
-     ${local.fire_lens_container},
+     ${module.firelens_log_config.fire_lens_container},
      {
        "portMappings": [
          {
@@ -519,9 +417,10 @@ resource "aws_ecs_task_definition" "device_task_definition" {
           ]
        }
      },
-     ${local.datadog_ecs_agent_task_def}
+     ${module.firelens_log_config.datadog_container}
    ]
 DEFINITION
+
 
 
 depends_on = [

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -405,14 +405,14 @@ DEFINITION
 }
 
 module "logging_configs" {
-  source            = "../logging_configs"
-  app_name          = local.device_app_name
-  environment_name  = terraform.workspace
-  task_name         = local.device_app_name
-  datadog_image     = var.datadog_image
+  source           = "../logging_configs"
+  app_name         = local.device_app_name
+  environment_name = terraform.workspace
+  task_name        = local.device_app_name
+  datadog_image    = var.datadog_image
   docker_image_tag = var.docker_image_tag
-  datadog_key_arn   = var.datadog_key_arn
-  region            = var.region
+  datadog_key_arn  = var.datadog_key_arn
+  region           = var.region
 
   tags = var.tags
 }

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -411,7 +411,7 @@ module "logging_configs" {
   environment_name  = var.environment_name
   task_name         = local.device_app_name
   datadog_image     = var.datadog_image
-  datadog_image_tag = var.datadog_image_tag
+  docker_image_tag = var.docker_image_tag
   datadog_key_arn   = var.datadog_key_arn
   region            = var.region
 

--- a/modules/device/variables.tf
+++ b/modules/device/variables.tf
@@ -43,10 +43,6 @@ variable "tags" {
   }
 }
 
-variable "environment_name" {
-  type = string
-}
-
 variable "datadog_image" {
   description = "Datadog container image"
   type        = string

--- a/modules/device/variables.tf
+++ b/modules/device/variables.tf
@@ -18,18 +18,23 @@ variable "smtp_username" {}
 variable "smtp_password" {}
 variable "service_count" {}
 variable "task_execution_role" {}
+
 variable "from_email" {
   default = "no-reply@nerves-hub.org"
 }
+
 variable "access_logs" {
   default = false
 }
+
 variable "access_logs_bucket" {
   default = ""
 }
+
 variable "access_logs_prefix" {
   default = "nerves-hub-device-nlb"
 }
+
 variable "tags" {
   description = "A mapping of tags to assign to the resources"
   type        = map(string)
@@ -44,5 +49,15 @@ variable "environment_name" {
 
 variable "datadog_image" {
   description = "Datadog container image"
-  type = string
+  type        = string
+}
+
+variable "datadog_image_tag" {
+  description = "Datadog container image tag"
+  type        = string
+}
+
+variable "datadog_key_arn" {
+  description = "Datadog Key"
+  type        = string
 }

--- a/modules/device/variables.tf
+++ b/modules/device/variables.tf
@@ -37,3 +37,12 @@ variable "tags" {
     terraform = true
   }
 }
+
+variable "environment_name" {
+  type = string
+}
+
+variable "datadog_image" {
+  description = "Datadog container image"
+  type = string
+}

--- a/modules/device/variables.tf
+++ b/modules/device/variables.tf
@@ -52,8 +52,8 @@ variable "datadog_image" {
   type        = string
 }
 
-variable "datadog_image_tag" {
-  description = "Datadog container image tag"
+variable "docker_image_tag" {
+  description = "Docker Image tag for Device Application"
   type        = string
 }
 

--- a/modules/ecs/cluster/README.md
+++ b/modules/ecs/cluster/README.md
@@ -1,0 +1,53 @@
+# cluster
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.app](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_ecs_cluster.ecs_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
+| [aws_security_group.lb_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allow_list_ipv4"></a> [allow\_list\_ipv4](#input\_allow\_list\_ipv4) | IPv4s that are allowed to access the cluster from load balancers | `any` | n/a | yes |
+| <a name="input_allow_list_ipv6"></a> [allow\_list\_ipv6](#input\_allow\_list\_ipv6) | IPv6s that are allowed to access the cluster from load balancers | `list` | `[]` | no |
+| <a name="input_aws_private_subnet_ids"></a> [aws\_private\_subnet\_ids](#input\_aws\_private\_subnet\_ids) | Subnet ids | `any` | n/a | yes |
+| <a name="input_aws_public_subnet_ids"></a> [aws\_public\_subnet\_ids](#input\_aws\_public\_subnet\_ids) | Subnet ids | `any` | n/a | yes |
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | The AWS region to create things in. | `any` | n/a | yes |
+| <a name="input_aws_vpc_id"></a> [aws\_vpc\_id](#input\_aws\_vpc\_id) | VPC id | `any` | n/a | yes |
+| <a name="input_container_insights"></a> [container\_insights](#input\_container\_insights) | ECS cluster container insights enabled or disabled | `bool` | `true` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Deploy environment | `any` | n/a | yes |
+| <a name="input_log_retention"></a> [log\_retention](#input\_log\_retention) | Cloud watch log retention days | `any` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources | `map(string)` | <pre>{<br>  "terraform": true<br>}</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | n/a |
+| <a name="output_lb_security_group_id"></a> [lb\_security\_group\_id](#output\_lb\_security\_group\_id) | n/a |
+| <a name="output_log_group_arn"></a> [log\_group\_arn](#output\_log\_group\_arn) | n/a |
+| <a name="output_log_group_name"></a> [log\_group\_name](#output\_log\_group\_name) | n/a |
+| <a name="output_name"></a> [name](#output\_name) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/logging_configs/README.md
+++ b/modules/logging_configs/README.md
@@ -1,0 +1,43 @@
+# logging_configs
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | n/a | `string` | n/a | yes |
+| <a name="input_datadog_image"></a> [datadog\_image](#input\_datadog\_image) | n/a | `string` | n/a | yes |
+| <a name="input_datadog_key_arn"></a> [datadog\_key\_arn](#input\_datadog\_key\_arn) | Datadog Key ARN | `string` | n/a | yes |
+| <a name="input_docker_image_tag"></a> [docker\_image\_tag](#input\_docker\_image\_tag) | Docker Image Tag of Application | `string` | n/a | yes |
+| <a name="input_environment_name"></a> [environment\_name](#input\_environment\_name) | n/a | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The AWS Region | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources | `map(string)` | <pre>{<br>  "terraform": true<br>}</pre> | no |
+| <a name="input_task_name"></a> [task\_name](#input\_task\_name) | n/a | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_datadog_container"></a> [datadog\_container](#output\_datadog\_container) | n/a |
+| <a name="output_datadog_key_arn"></a> [datadog\_key\_arn](#output\_datadog\_key\_arn) | n/a |
+| <a name="output_fire_lens_container"></a> [fire\_lens\_container](#output\_fire\_lens\_container) | n/a |
+| <a name="output_log_configuration"></a> [log\_configuration](#output\_log\_configuration) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/logging_configs/main.tf
+++ b/modules/logging_configs/main.tf
@@ -1,0 +1,193 @@
+# This is just a module to provide a template for creating a log configuration for an ECS task definition.
+
+locals {
+  tld = var.region == "eu-central-1" ? "eu" : "com"
+
+  fire_lens_container = <<EOF
+  {
+    "essential": true,
+    "image": "906394416424.dkr.ecr.${var.region}.amazonaws.com/aws-for-fluent-bit:stable",
+    "name": "log_router",
+    "cpu": 0,
+    "user": "0",
+    "environment": [],
+    "volumesFrom": [],
+    "portMappings": [],
+    "mountPoints": [],
+    "firelensConfiguration": {
+      "type": "fluentbit",
+      "options": {
+        "enable-ecs-log-metadata": "true"
+      }
+    },
+    "memoryReservation": 50,
+    "dockerLabels": {
+      "com.datadoghq.tags.env": "${var.environment_name}",
+      "com.datadoghq.tags.service": "${var.app_name}",
+      "com.datadoghq.tags.version": "${var.docker_image_tag}"
+    }
+  }
+EOF
+
+  datadog_ecs_agent_task_def = <<EOF
+{
+  "name": "datadog-agent",
+  "image": "${var.datadog_image}",
+  "essential": false,
+  "memoryReservation": 256,
+  "cpu": 10,
+  "mountPoints": [],
+  "volumesFrom": [],
+  "portMappings": [
+    {
+      "containerPort": 8125,
+      "hostPort": 8125,
+      "protocol": "udp"
+    },
+    {
+      "containerPort": 8126,
+      "hostPort": 8126,
+      "protocol": "tcp"
+    }
+  ],
+  "environment": [
+    {
+      "name": "ECS_FARGATE",
+      "value": "true"
+    },
+    {
+      "name": "DD_DOGSTATSD_TAG_CARDINALITY",
+      "value": "orchestrator"
+    },
+    {
+      "name": "DD_LOG_LEVEL",
+      "value": "warn"
+    },
+    {
+      "name": "DD_APM_ENABLED",
+      "value": "true"
+    },
+    {
+      "name": "DD_APM_NON_LOCAL_TRAFFIC",
+      "value": "true"
+    },
+    {
+      "name": "DD_PROCESS_AGENT_ENABLED",
+      "value": "true"
+    },
+    {
+      "name": "DD_HEALTH_PORT",
+      "value": "5555"
+    },
+    {
+      "name": "DD_APM_RECEIVER_PORT",
+      "value": "8126"
+    },
+    {
+      "name": "DD_DOGSTATSD_NON_LOCAL_TRAFFIC",
+      "value": "true"
+    },
+    {
+	  "name": "DD_SITE",
+	  "value": "datadoghq.${local.tld}"
+    },
+    {
+      "name": "DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL",
+      "value": "true"
+    },
+    {
+      "name": "DD_DOGSTATSD_PORT",
+      "value": "8125"
+    },
+    {
+      "name": "DD_ENV",
+      "value": "${var.environment_name}"
+    },
+    {
+      "name": "DD_SERVICE",
+      "value": "${var.app_name}"
+    },
+    {
+      "name": "DD_VERSION",
+      "value": "${var.docker_image_tag}"
+    },
+    {
+      "name": "DD_DOCKER_LABELS_AS_TAGS",
+      "value": "{\"com.datadoghq.tags.service\": \"service\", \"com.datadoghq.tags.version\": \"version\", \"com.datadoghq.tags.env\": \"env\"}"
+    },
+    {
+      "name": "DD_DOGSTATSD_TAGS",
+      "value": "[\"env:${var.environment_name}\", \"service:${var.app_name}\", \"version:${var.docker_image_tag}\"]"
+    }
+  ],
+  "secrets": [
+    {
+      "name": "DD_API_KEY",
+      "valueFrom": "${var.datadog_key_arn}"
+    }
+  ],
+  "dockerLabels": {
+          "com.datadoghq.tags.env": "${var.environment_name}",
+          "com.datadoghq.tags.service": "${var.app_name}",
+          "com.datadoghq.tags.version": "${var.docker_image_tag}"
+  },
+  ${local.datadog_log_configuration}
+}
+EOF
+
+  log_configuration = <<EOF
+  "logConfiguration": {
+        "logDriver": "awsfirelens",
+        "options": {
+          "Name": "datadog",
+          "compress": "gzip",
+          "Host": "http-intake.logs.datadoghq.${local.tld}",
+          "dd_service": "${var.app_name}",
+          "dd_source": "elixir",
+          "dd_message_key": "log",
+          "dd_tags": "env:${var.environment_name},application:${var.app_name}-${var.environment_name},version:${var.docker_image_tag},task:${var.task_name}",
+          "TLS": "on",
+          "provider": "ecs"
+        },
+        "secretOptions": [
+        {
+          "name": "apikey",
+          "valueFrom": "${var.datadog_key_arn}"
+        }
+      ]
+    },
+        "dockerLabels": {
+          "com.datadoghq.tags.env": "${var.environment_name}",
+          "com.datadoghq.tags.service": "${var.app_name}",
+          "com.datadoghq.tags.version": "${var.docker_image_tag}"
+        }
+EOF
+
+  datadog_log_configuration = <<EOF
+  "logConfiguration": {
+        "logDriver": "awsfirelens",
+        "options": {
+          "Name": "datadog",
+          "compress": "gzip",
+          "Host": "http-intake.logs.datadoghq.${local.tld}",
+          "dd_service": "${var.app_name}",
+          "dd_source": "datadog",
+          "dd_message_key": "log",
+          "dd_tags": "env:${var.environment_name},application:${var.app_name}-${var.environment_name},version:${var.docker_image_tag},task:${var.task_name}",
+          "TLS": "on",
+          "provider": "ecs"
+        },
+        "secretOptions": [
+        {
+          "name": "apikey",
+          "valueFrom": "${var.datadog_key_arn}"
+        }
+      ]
+    },
+        "dockerLabels": {
+          "com.datadoghq.tags.env": "${var.environment_name}",
+          "com.datadoghq.tags.service": "${var.app_name}",
+          "com.datadoghq.tags.version": "${var.docker_image_tag}"
+        }
+EOF
+}

--- a/modules/logging_configs/output.tf
+++ b/modules/logging_configs/output.tf
@@ -1,0 +1,15 @@
+output "fire_lens_container" {
+  value = local.fire_lens_container
+}
+
+output "log_configuration" {
+  value = local.log_configuration
+}
+
+output "datadog_container" {
+  value = local.datadog_ecs_agent_task_def
+}
+
+output "datadog_key_arn" {
+  value = var.datadog_key_arn
+}

--- a/modules/logging_configs/variables.tf
+++ b/modules/logging_configs/variables.tf
@@ -1,0 +1,38 @@
+variable "environment_name" {
+  type = string
+}
+
+variable "app_name" {
+  type = string
+}
+
+variable "task_name" {
+  type = string
+}
+
+variable "datadog_image" {
+  type = string
+}
+
+variable "region" {
+  type        = string
+  description = "The AWS Region"
+}
+
+variable "tags" {
+  description = "A mapping of tags to assign to the resources"
+  type        = map(string)
+  default = {
+    terraform = true
+  }
+}
+
+variable "datadog_key_arn" {
+  description = "Datadog Key ARN"
+  type        = string
+}
+
+variable "docker_image_tag" {
+  description = "Docker Image Tag of Application"
+  type        = string  
+}

--- a/modules/logging_configs/variables.tf
+++ b/modules/logging_configs/variables.tf
@@ -34,5 +34,5 @@ variable "datadog_key_arn" {
 
 variable "docker_image_tag" {
   description = "Docker Image Tag of Application"
-  type        = string  
+  type        = string
 }

--- a/modules/logging_configs/versions.tf
+++ b/modules/logging_configs/versions.tf
@@ -1,0 +1,4 @@
+terraform {
+  required_providers {}
+  required_version = ">= 0.12"
+}

--- a/modules/rds/README.md
+++ b/modules/rds/README.md
@@ -1,0 +1,73 @@
+# rds
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_db_instance.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
+| [aws_db_option_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_option_group) | resource |
+| [aws_db_parameter_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group) | resource |
+| [aws_security_group.rds_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | n/a | `number` | n/a | yes |
+| <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | n/a | `bool` | `true` | no |
+| <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | n/a | `number` | `1` | no |
+| <a name="input_cidr_blocks"></a> [cidr\_blocks](#input\_cidr\_blocks) | n/a | `list` | <pre>[<br>  ""<br>]</pre> | no |
+| <a name="input_cloudwatch_log_exports"></a> [cloudwatch\_log\_exports](#input\_cloudwatch\_log\_exports) | n/a | `list` | `[]` | no |
+| <a name="input_copy_tags_to_snapshot"></a> [copy\_tags\_to\_snapshot](#input\_copy\_tags\_to\_snapshot) | n/a | `bool` | `false` | no |
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | n/a | `bool` | `false` | no |
+| <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | The Engine version of the Postgres database server | `any` | n/a | yes |
+| <a name="input_family"></a> [family](#input\_family) | n/a | `string` | `"postgres11"` | no |
+| <a name="input_identifier"></a> [identifier](#input\_identifier) | n/a | `any` | n/a | yes |
+| <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | The Instance class of the Postgres database server | `any` | n/a | yes |
+| <a name="input_kms_key"></a> [kms\_key](#input\_kms\_key) | n/a | `any` | n/a | yes |
+| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | n/a | `string` | `null` | no |
+| <a name="input_major_engine_version"></a> [major\_engine\_version](#input\_major\_engine\_version) | n/a | `number` | `11` | no |
+| <a name="input_monitoring_interval"></a> [monitoring\_interval](#input\_monitoring\_interval) | n/a | `number` | `0` | no |
+| <a name="input_monitoring_role_arn"></a> [monitoring\_role\_arn](#input\_monitoring\_role\_arn) | n/a | `string` | `null` | no |
+| <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | n/a | `bool` | `false` | no |
+| <a name="input_name"></a> [name](#input\_name) | n/a | `any` | n/a | yes |
+| <a name="input_option_group_name"></a> [option\_group\_name](#input\_option\_group\_name) | n/a | `string` | `""` | no |
+| <a name="input_options"></a> [options](#input\_options) | n/a | `list` | `[]` | no |
+| <a name="input_parameter_group_name"></a> [parameter\_group\_name](#input\_parameter\_group\_name) | n/a | `string` | `""` | no |
+| <a name="input_parameters"></a> [parameters](#input\_parameters) | n/a | `list` | `[]` | no |
+| <a name="input_password"></a> [password](#input\_password) | n/a | `any` | n/a | yes |
+| <a name="input_performance_insights"></a> [performance\_insights](#input\_performance\_insights) | n/a | `bool` | `false` | no |
+| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | n/a | `list` | <pre>[<br>  ""<br>]</pre> | no |
+| <a name="input_subnet_group"></a> [subnet\_group](#input\_subnet\_group) | DB subnet group | `any` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources | `map(string)` | <pre>{<br>  "terraform": true<br>}</pre> | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | Define maximum timeout for deletion of `aws_db_option_group` resource | `map(string)` | <pre>{<br>  "delete": "15m"<br>}</pre> | no |
+| <a name="input_username"></a> [username](#input\_username) | n/a | `any` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | n/a | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_db_arn"></a> [db\_arn](#output\_db\_arn) | n/a |
+| <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | n/a |
+| <a name="output_name"></a> [name](#output\_name) | n/a |
+| <a name="output_password"></a> [password](#output\_password) | n/a |
+| <a name="output_security_group"></a> [security\_group](#output\_security\_group) | n/a |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | n/a |
+| <a name="output_username"></a> [username](#output\_username) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/route53/README.md
+++ b/modules/route53/README.md
@@ -1,0 +1,46 @@
+# route53
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_route53_record.api_dns_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.device_dns_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.www_dns_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_zone.dns_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_api_dns_record_name"></a> [api\_dns\_record\_name](#input\_api\_dns\_record\_name) | n/a | `any` | n/a | yes |
+| <a name="input_api_lb"></a> [api\_lb](#input\_api\_lb) | n/a | `any` | n/a | yes |
+| <a name="input_device_dns_record_name"></a> [device\_dns\_record\_name](#input\_device\_dns\_record\_name) | n/a | `any` | n/a | yes |
+| <a name="input_device_lb"></a> [device\_lb](#input\_device\_lb) | n/a | `any` | n/a | yes |
+| <a name="input_dns_zone"></a> [dns\_zone](#input\_dns\_zone) | n/a | `any` | n/a | yes |
+| <a name="input_is_api_alb"></a> [is\_api\_alb](#input\_is\_api\_alb) | Whether or not the api has an application load balancer | `bool` | `false` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources | `map(string)` | <pre>{<br>  "terraform": true<br>}</pre> | no |
+| <a name="input_www_dns_record_name"></a> [www\_dns\_record\_name](#input\_www\_dns\_record\_name) | n/a | `any` | n/a | yes |
+| <a name="input_www_lb"></a> [www\_lb](#input\_www\_lb) | n/a | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_hosted_zone_id"></a> [hosted\_zone\_id](#output\_hosted\_zone\_id) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ses/README.md
+++ b/modules/ses/README.md
@@ -1,0 +1,45 @@
+# ses
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_group.ses_sendmail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group) | resource |
+| [aws_iam_group_policy_attachment.ses_sendmail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
+| [aws_iam_policy.SendRawEmail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_user.ses_smtp_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
+| [aws_iam_user_group_membership.ses_sendmail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_group_membership) | resource |
+| [aws_ses_email_identity.nerves_hub_send](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ses_email_identity) | resource |
+| [aws_iam_policy_document.ses_sendmail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_email_identity"></a> [email\_identity](#input\_email\_identity) | n/a | `any` | n/a | yes |
+| <a name="input_group_name"></a> [group\_name](#input\_group\_name) | n/a | `any` | n/a | yes |
+| <a name="input_policy_name"></a> [policy\_name](#input\_policy\_name) | n/a | `any` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `any` | n/a | yes |
+| <a name="input_user"></a> [user](#input\_user) | n/a | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_identity_arn"></a> [identity\_arn](#output\_identity\_arn) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -1,0 +1,58 @@
+# vpc
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 2.63 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_azs"></a> [azs](#input\_azs) | A list of availability zones names or ids in the region | `list(string)` | n/a | yes |
+| <a name="input_cidr"></a> [cidr](#input\_cidr) | The CIDR block for the vpc | `string` | n/a | yes |
+| <a name="input_create_database_subnet_group"></a> [create\_database\_subnet\_group](#input\_create\_database\_subnet\_group) | n/a | `bool` | `true` | no |
+| <a name="input_database_subnets"></a> [database\_subnets](#input\_database\_subnets) | A list of database subnets | `list(string)` | n/a | yes |
+| <a name="input_default_vpc_enable_dns_hostnames"></a> [default\_vpc\_enable\_dns\_hostnames](#input\_default\_vpc\_enable\_dns\_hostnames) | n/a | `bool` | `false` | no |
+| <a name="input_default_vpc_name"></a> [default\_vpc\_name](#input\_default\_vpc\_name) | n/a | `string` | `""` | no |
+| <a name="input_enable_dhcp_options"></a> [enable\_dhcp\_options](#input\_enable\_dhcp\_options) | n/a | `bool` | `false` | no |
+| <a name="input_enable_dns_hostnames"></a> [enable\_dns\_hostnames](#input\_enable\_dns\_hostnames) | n/a | `bool` | `false` | no |
+| <a name="input_enable_dns_support"></a> [enable\_dns\_support](#input\_enable\_dns\_support) | n/a | `bool` | `true` | no |
+| <a name="input_enable_nat_gateway"></a> [enable\_nat\_gateway](#input\_enable\_nat\_gateway) | n/a | `bool` | `true` | no |
+| <a name="input_enable_s3_endpoint"></a> [enable\_s3\_endpoint](#input\_enable\_s3\_endpoint) | n/a | `bool` | `false` | no |
+| <a name="input_enable_vpn_gateway"></a> [enable\_vpn\_gateway](#input\_enable\_vpn\_gateway) | n/a | `bool` | `false` | no |
+| <a name="input_manage_default_vpc"></a> [manage\_default\_vpc](#input\_manage\_default\_vpc) | n/a | `bool` | `false` | no |
+| <a name="input_name"></a> [name](#input\_name) | The application name | `string` | n/a | yes |
+| <a name="input_one_nat_gateway_per_az"></a> [one\_nat\_gateway\_per\_az](#input\_one\_nat\_gateway\_per\_az) | n/a | `bool` | `false` | no |
+| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | A list of private subnets inside the VPC | `list(string)` | n/a | yes |
+| <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | A list of public subnets inside the VPC | `list(string)` | n/a | yes |
+| <a name="input_single_nat_gateway"></a> [single\_nat\_gateway](#input\_single\_nat\_gateway) | n/a | `bool` | `false` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources | `map(string)` | <pre>{<br>  "terraform": true<br>}</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cidr_block"></a> [cidr\_block](#output\_cidr\_block) | n/a |
+| <a name="output_database_route_table_ids"></a> [database\_route\_table\_ids](#output\_database\_route\_table\_ids) | n/a |
+| <a name="output_database_subnet_group"></a> [database\_subnet\_group](#output\_database\_subnet\_group) | n/a |
+| <a name="output_private_route_table_ids"></a> [private\_route\_table\_ids](#output\_private\_route\_table\_ids) | n/a |
+| <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | n/a |
+| <a name="output_public_route_table_ids"></a> [public\_route\_table\_ids](#output\_public\_route\_table\_ids) | n/a |
+| <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | n/a |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/www/README.md
+++ b/modules/www/README.md
@@ -1,0 +1,91 @@
+# www
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_ecs_service.www_ecs_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.www_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_iam_policy.www_task_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.www_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.www_role_policy_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lb.www_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.www_lb_listener](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.www_ssl_lb_listener](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.www_lb_tg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ses_from_email](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ssm_app_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ssm_aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ssm_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ssm_host](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ssm_port](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ssm_s3_bucket_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ssm_s3_log_bucket_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ssm_s3_ssl_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ssm_secret_db_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ssm_secret_erl_cookie](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ssm_secret_live_view_signing_salt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ssm_secret_secret_key_base](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ssm_secret_smtp_password](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ssm_ses_port](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ssm_ses_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_www_ssm_smtp_username](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [random_integer.target_group_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
+| [aws_iam_policy_document.www_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_access_logs"></a> [access\_logs](#input\_access\_logs) | n/a | `bool` | `false` | no |
+| <a name="input_access_logs_bucket"></a> [access\_logs\_bucket](#input\_access\_logs\_bucket) | n/a | `string` | `""` | no |
+| <a name="input_access_logs_prefix"></a> [access\_logs\_prefix](#input\_access\_logs\_prefix) | n/a | `string` | `"nerves-hub-www-alb"` | no |
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | n/a | `any` | n/a | yes |
+| <a name="input_app_bucket"></a> [app\_bucket](#input\_app\_bucket) | n/a | `any` | n/a | yes |
+| <a name="input_ca_bucket"></a> [ca\_bucket](#input\_ca\_bucket) | n/a | `any` | n/a | yes |
+| <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | n/a | `any` | n/a | yes |
+| <a name="input_cluster"></a> [cluster](#input\_cluster) | n/a | `any` | n/a | yes |
+| <a name="input_db"></a> [db](#input\_db) | n/a | `any` | n/a | yes |
+| <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | n/a | `any` | n/a | yes |
+| <a name="input_erl_cookie"></a> [erl\_cookie](#input\_erl\_cookie) | n/a | `any` | n/a | yes |
+| <a name="input_from_email"></a> [from\_email](#input\_from\_email) | n/a | `string` | `"no-reply@nerves-hub.org"` | no |
+| <a name="input_host_name"></a> [host\_name](#input\_host\_name) | n/a | `any` | n/a | yes |
+| <a name="input_internal_lb"></a> [internal\_lb](#input\_internal\_lb) | Whether or not the load balancer is internal | `bool` | `false` | no |
+| <a name="input_kms_key"></a> [kms\_key](#input\_kms\_key) | n/a | `any` | n/a | yes |
+| <a name="input_lb_security_group_id"></a> [lb\_security\_group\_id](#input\_lb\_security\_group\_id) | n/a | `any` | n/a | yes |
+| <a name="input_live_view_signing_salt"></a> [live\_view\_signing\_salt](#input\_live\_view\_signing\_salt) | n/a | `any` | n/a | yes |
+| <a name="input_log_bucket"></a> [log\_bucket](#input\_log\_bucket) | n/a | `any` | n/a | yes |
+| <a name="input_log_group"></a> [log\_group](#input\_log\_group) | n/a | `any` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | n/a | `any` | n/a | yes |
+| <a name="input_secret_key_base"></a> [secret\_key\_base](#input\_secret\_key\_base) | n/a | `any` | n/a | yes |
+| <a name="input_service_count"></a> [service\_count](#input\_service\_count) | n/a | `any` | n/a | yes |
+| <a name="input_smtp_password"></a> [smtp\_password](#input\_smtp\_password) | n/a | `any` | n/a | yes |
+| <a name="input_smtp_username"></a> [smtp\_username](#input\_smtp\_username) | n/a | `any` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources | `map(string)` | <pre>{<br>  "terraform": true<br>}</pre> | no |
+| <a name="input_task_execution_role"></a> [task\_execution\_role](#input\_task\_execution\_role) | n/a | `any` | n/a | yes |
+| <a name="input_task_security_group_id"></a> [task\_security\_group\_id](#input\_task\_security\_group\_id) | n/a | `any` | n/a | yes |
+| <a name="input_vpc"></a> [vpc](#input\_vpc) | n/a | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_lb_dns_name"></a> [lb\_dns\_name](#output\_lb\_dns\_name) | n/a |
+| <a name="output_lb_zone_id"></a> [lb\_zone\_id](#output\_lb\_zone\_id) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,0 +1,71 @@
+# setup
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 2.20 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 2.1 |
+| <a name="requirement_template"></a> [template](#requirement\_template) | ~> 2.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 2.20 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_backend"></a> [backend](#module\_backend) | ../modules/backend | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allow_list_ipv4"></a> [allow\_list\_ipv4](#input\_allow\_list\_ipv4) | The allowed list of IPs for accessing the cluster | `list` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_api_image"></a> [api\_image](#input\_api\_image) | The docker image of the nerves\_hub\_api app | `string` | `"nerveshub/nerves_hub_api:latest"` | no |
+| <a name="input_api_service_desired_count"></a> [api\_service\_desired\_count](#input\_api\_service\_desired\_count) | The number of NervesHubAPI containers to run | `string` | `"1"` | no |
+| <a name="input_billing_enabled"></a> [billing\_enabled](#input\_billing\_enabled) | Enable billing? | `bool` | `false` | no |
+| <a name="input_billing_image"></a> [billing\_image](#input\_billing\_image) | The docker image of the nerves\_hub\_billing app | `string` | `"nerveshub/nerves_hub_billing:latest"` | no |
+| <a name="input_billing_service_desired_count"></a> [billing\_service\_desired\_count](#input\_billing\_service\_desired\_count) | The number of NervesHubBilling containers to run | `string` | `"1"` | no |
+| <a name="input_bucket"></a> [bucket](#input\_bucket) | AWS S3 Bucket name for Terraform state | `any` | n/a | yes |
+| <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | AWS S3 Bucket prefix for application state buckets | `any` | n/a | yes |
+| <a name="input_ca_db_name"></a> [ca\_db\_name](#input\_ca\_db\_name) | The name of the CA database | `string` | `"nerves_hub_ca"` | no |
+| <a name="input_ca_image"></a> [ca\_image](#input\_ca\_image) | The docker image of the nerves\_hub\_ca app | `string` | `"nerveshub/nerves_hub_ca:latest"` | no |
+| <a name="input_ca_service_desired_count"></a> [ca\_service\_desired\_count](#input\_ca\_service\_desired\_count) | The number of NervesHubCA containers to run | `string` | `"1"` | no |
+| <a name="input_db_allocated_storage"></a> [db\_allocated\_storage](#input\_db\_allocated\_storage) | n/a | `number` | `20` | no |
+| <a name="input_db_engine_version"></a> [db\_engine\_version](#input\_db\_engine\_version) | The Engine version of the Postgres database server | `string` | `"11.4"` | no |
+| <a name="input_db_instance_class"></a> [db\_instance\_class](#input\_db\_instance\_class) | The Instance class of the Postgres database server | `string` | `"db.t2.small"` | no |
+| <a name="input_db_password"></a> [db\_password](#input\_db\_password) | Database password | `any` | n/a | yes |
+| <a name="input_db_username"></a> [db\_username](#input\_db\_username) | Database username | `any` | n/a | yes |
+| <a name="input_device_image"></a> [device\_image](#input\_device\_image) | The docker image of the nerves\_hub\_device app | `string` | `"nerveshub/nerves_hub_device:latest"` | no |
+| <a name="input_device_service_desired_count"></a> [device\_service\_desired\_count](#input\_device\_service\_desired\_count) | The number of NervesHubDevice containers to run | `string` | `"1"` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | The domain name | `any` | n/a | yes |
+| <a name="input_dynamodb_table"></a> [dynamodb\_table](#input\_dynamodb\_table) | AWS DynamoDB table for state locking | `any` | n/a | yes |
+| <a name="input_erl_cookie"></a> [erl\_cookie](#input\_erl\_cookie) | The Erlang distribution cookie value | `any` | n/a | yes |
+| <a name="input_key"></a> [key](#input\_key) | Key for Terraform state at S3 bucket | `any` | n/a | yes |
+| <a name="input_log_retention"></a> [log\_retention](#input\_log\_retention) | Cloud watch log retention days | `number` | `90` | no |
+| <a name="input_operators"></a> [operators](#input\_operators) | n/a | `list` | n/a | yes |
+| <a name="input_profile"></a> [profile](#input\_profile) | AWS profile | `any` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `any` | n/a | yes |
+| <a name="input_web_db_name"></a> [web\_db\_name](#input\_web\_db\_name) | The name of the web database | `string` | `"nerves_hub_web"` | no |
+| <a name="input_web_secret_key_base"></a> [web\_secret\_key\_base](#input\_web\_secret\_key\_base) | The secret key base for sessions | `any` | n/a | yes |
+| <a name="input_web_smtp_password"></a> [web\_smtp\_password](#input\_web\_smtp\_password) | The SES SMTP password | `any` | n/a | yes |
+| <a name="input_web_smtp_username"></a> [web\_smtp\_username](#input\_web\_smtp\_username) | The SES SMTP username | `any` | n/a | yes |
+| <a name="input_www_image"></a> [www\_image](#input\_www\_image) | The docker image of the nerves\_hub\_www app | `string` | `"nerveshub/nerves_hub_www:latest"` | no |
+| <a name="input_www_live_view_signing_salt"></a> [www\_live\_view\_signing\_salt](#input\_www\_live\_view\_signing\_salt) | The signing salt to use for Phoenix LiveView | `any` | n/a | yes |
+| <a name="input_www_service_desired_count"></a> [www\_service\_desired\_count](#input\_www\_service\_desired\_count) | The number of NervesHubWWW containers to run | `string` | `"1"` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
Description: This adds the Firelens Logging container as well as the Datadog Agent container to the Device Module's Task definition

Tests: 
* To see it in use, you may login to the ENG account and see it running in the ECS Cluster, `nerves-hub-dev` ([link](https://us-east-1.console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/nerves-hub-dev/services))
* To see the big picture, please see [this closed PR](https://github.com/smartrent/nerves-hub-terraform/pull/21/files). There are some changes listed in that PR that are not mine and there are some I found unnecessary that were removed.

This PR is four of ~~six~~ five to be merged.