### PR TITLE
TECH: Vars for resources and adding DD_ENV

### DIFF
--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -77,6 +77,7 @@
 | <a name="input_ca_host"></a> [ca\_host](#input\_ca\_host) | n/a | `any` | n/a | yes |
 | <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | n/a | `string` | `""` | no |
 | <a name="input_cluster"></a> [cluster](#input\_cluster) | n/a | `any` | n/a | yes |
+| <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU resource allocation | `string` | `"256"` | no |
 | <a name="input_datadog_image"></a> [datadog\_image](#input\_datadog\_image) | Datadog container image | `string` | n/a | yes |
 | <a name="input_datadog_key_arn"></a> [datadog\_key\_arn](#input\_datadog\_key\_arn) | Datadog Key | `string` | n/a | yes |
 | <a name="input_db"></a> [db](#input\_db) | n/a | `any` | n/a | yes |
@@ -89,6 +90,7 @@
 | <a name="input_internal_lb"></a> [internal\_lb](#input\_internal\_lb) | Whether or not the load balancer is internal | `bool` | `false` | no |
 | <a name="input_kms_key"></a> [kms\_key](#input\_kms\_key) | n/a | `any` | n/a | yes |
 | <a name="input_log_bucket"></a> [log\_bucket](#input\_log\_bucket) | n/a | `any` | n/a | yes |
+| <a name="input_memory"></a> [memory](#input\_memory) | Memory resource allocation | `string` | `"512"` | no |
 | <a name="input_nlb"></a> [nlb](#input\_nlb) | n/a | `bool` | `true` | no |
 | <a name="input_region"></a> [region](#input\_region) | n/a | `any` | n/a | yes |
 | <a name="input_secret_key_base"></a> [secret\_key\_base](#input\_secret\_key\_base) | n/a | `any` | n/a | yes |

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -10,7 +10,8 @@ locals {
 
   ecs_shared_env_vars = <<EOF
     { "name" : "ENVIRONMENT", "value" : "${terraform.workspace}" },
-    { "name" : "APP_NAME", "value" : "${local.app_name}" }
+    { "name" : "APP_NAME", "value" : "${local.app_name}" },
+    { "name" : "DD_ENV", "value" : "${terraform.workspace}" }
 EOF
 
 }
@@ -376,8 +377,8 @@ resource "aws_ecs_task_definition" "api_task_definition" {
 
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = "256"
-  memory                   = "512"
+  cpu                      = var.cpu
+  memory                   = var.memory
 
   tags = var.tags
 

--- a/modules/api/variables.tf
+++ b/modules/api/variables.tf
@@ -21,6 +21,16 @@ variable "service_count" {
 variable "api_public_service_count" {
   default = 0
 }
+variable "cpu" {
+  type        = string
+  description = "CPU resource allocation"
+  default     = "256"
+}
+variable "memory" {
+  type        = string
+  description = "Memory resource allocation"
+  default     = "512"
+}
 variable "task_execution_role" {}
 variable "allow_list_ipv4" {
   default = []

--- a/modules/device/README.md
+++ b/modules/device/README.md
@@ -63,6 +63,7 @@
 | <a name="input_app_bucket"></a> [app\_bucket](#input\_app\_bucket) | n/a | `any` | n/a | yes |
 | <a name="input_ca_bucket"></a> [ca\_bucket](#input\_ca\_bucket) | n/a | `any` | n/a | yes |
 | <a name="input_cluster"></a> [cluster](#input\_cluster) | n/a | `any` | n/a | yes |
+| <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU resource allocation | `string` | `"256"` | no |
 | <a name="input_datadog_image"></a> [datadog\_image](#input\_datadog\_image) | Datadog container image | `string` | n/a | yes |
 | <a name="input_datadog_key_arn"></a> [datadog\_key\_arn](#input\_datadog\_key\_arn) | Datadog Key | `string` | n/a | yes |
 | <a name="input_db"></a> [db](#input\_db) | n/a | `any` | n/a | yes |
@@ -73,6 +74,7 @@
 | <a name="input_host_name"></a> [host\_name](#input\_host\_name) | n/a | `any` | n/a | yes |
 | <a name="input_kms_key"></a> [kms\_key](#input\_kms\_key) | n/a | `any` | n/a | yes |
 | <a name="input_log_bucket"></a> [log\_bucket](#input\_log\_bucket) | n/a | `any` | n/a | yes |
+| <a name="input_memory"></a> [memory](#input\_memory) | Memory resource allocation | `string` | `"512"` | no |
 | <a name="input_region"></a> [region](#input\_region) | n/a | `any` | n/a | yes |
 | <a name="input_secret_key_base"></a> [secret\_key\_base](#input\_secret\_key\_base) | n/a | `any` | n/a | yes |
 | <a name="input_service_count"></a> [service\_count](#input\_service\_count) | n/a | `any` | n/a | yes |

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -5,7 +5,8 @@ locals {
 
   ecs_shared_env_vars = <<EOF
     { "name" : "ENVIRONMENT", "value" : "${terraform.workspace}" },
-    { "name" : "APP_NAME", "value" : "${local.device_app_name}" }
+    { "name" : "APP_NAME", "value" : "${local.device_app_name}" },
+    { "name" : "DD_ENV", "value" : "${terraform.workspace}" }
 EOF
 
 }
@@ -363,8 +364,8 @@ resource "aws_ecs_task_definition" "device_task_definition" {
 
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = "256"
-  memory                   = "512"
+  cpu                      = var.cpu
+  memory                   = var.memory
 
   container_definitions = <<DEFINITION
    [

--- a/modules/device/variables.tf
+++ b/modules/device/variables.tf
@@ -17,6 +17,17 @@ variable "smtp_password" {}
 variable "service_count" {}
 variable "task_execution_role" {}
 
+variable "cpu" {
+  type        = string
+  description = "CPU resource allocation"
+  default     = "256"
+}
+variable "memory" {
+  type        = string
+  description = "Memory resource allocation"
+  default     = "512"
+}
+
 variable "from_email" {
   default = "no-reply@nerves-hub.org"
 }

--- a/modules/www/README.md
+++ b/modules/www/README.md
@@ -66,6 +66,7 @@
 | <a name="input_ca_bucket"></a> [ca\_bucket](#input\_ca\_bucket) | n/a | `any` | n/a | yes |
 | <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | n/a | `any` | n/a | yes |
 | <a name="input_cluster"></a> [cluster](#input\_cluster) | n/a | `any` | n/a | yes |
+| <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU resource allocation | `string` | `"256"` | no |
 | <a name="input_datadog_image"></a> [datadog\_image](#input\_datadog\_image) | Datadog container image | `string` | n/a | yes |
 | <a name="input_datadog_key_arn"></a> [datadog\_key\_arn](#input\_datadog\_key\_arn) | Datadog Key | `string` | n/a | yes |
 | <a name="input_db"></a> [db](#input\_db) | n/a | `any` | n/a | yes |
@@ -79,6 +80,7 @@
 | <a name="input_lb_security_group_id"></a> [lb\_security\_group\_id](#input\_lb\_security\_group\_id) | n/a | `any` | n/a | yes |
 | <a name="input_live_view_signing_salt"></a> [live\_view\_signing\_salt](#input\_live\_view\_signing\_salt) | n/a | `any` | n/a | yes |
 | <a name="input_log_bucket"></a> [log\_bucket](#input\_log\_bucket) | n/a | `any` | n/a | yes |
+| <a name="input_memory"></a> [memory](#input\_memory) | Memory resource allocation | `string` | `"512"` | no |
 | <a name="input_region"></a> [region](#input\_region) | n/a | `any` | n/a | yes |
 | <a name="input_secret_key_base"></a> [secret\_key\_base](#input\_secret\_key\_base) | n/a | `any` | n/a | yes |
 | <a name="input_service_count"></a> [service\_count](#input\_service\_count) | n/a | `any` | n/a | yes |

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -5,7 +5,8 @@ locals {
 
   ecs_shared_env_vars = <<EOF
     { "name" : "ENVIRONMENT", "value" : "${terraform.workspace}" },
-    { "name" : "APP_NAME", "value" : "${local.app_name}" }
+    { "name" : "APP_NAME", "value" : "${local.app_name}" },
+    { "name" : "DD_ENV", "value" : "${terraform.workspace}" }
 EOF
 
 }
@@ -392,8 +393,8 @@ resource "aws_ecs_task_definition" "www_task_definition" {
 
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = "256"
-  memory                   = "512"
+  cpu                      = var.cpu
+  memory                   = var.memory
   tags                     = var.tags
 
   container_definitions = <<DEFINITION

--- a/modules/www/variables.tf
+++ b/modules/www/variables.tf
@@ -19,6 +19,16 @@ variable "smtp_password" {}
 variable "service_count" {}
 variable "task_execution_role" {}
 variable "certificate_arn" {}
+variable "cpu" {
+  type        = string
+  description = "CPU resource allocation"
+  default     = "256"
+}
+variable "memory" {
+  type        = string
+  description = "Memory resource allocation"
+  default     = "512"
+}
 
 variable "from_email" {
   default = "no-reply@nerves-hub.org"


### PR DESCRIPTION
## Description

We want to be able to increase resources as needed so I made some vars to enable that for web/api/device. 

Also we're referencing `DD_ENV` var that's not passed to the app container. We can either change that here or we can update the env var to use existing `ENVIRONMENT` var. https://github.com/smartrent/nerves_hub_web/blob/8c93cc229c9a1df1348fd917b32a40d8263df929/apps/nerves_hub_www/config/release.exs#L60

Did it this way to test easily and also standardize. 