### PR TITLE
TECH: New variable for setting allow_major_version_upgrade

### DIFF
--- a/modules/rds/README.md
+++ b/modules/rds/README.md
@@ -32,6 +32,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | n/a | `number` | n/a | yes |
+| <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | n/a | `bool` | `false` | no |
 | <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | n/a | `bool` | `true` | no |
 | <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | n/a | `number` | `1` | no |
 | <a name="input_cidr_blocks"></a> [cidr\_blocks](#input\_cidr\_blocks) | n/a | `list` | <pre>[<br>  ""<br>]</pre> | no |

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -45,31 +45,32 @@ resource "aws_security_group" "rds_security_group" {
 }
 
 resource "aws_db_instance" "default" {
-  identifier                 = var.identifier
-  db_name                    = var.name
-  publicly_accessible        = false
-  apply_immediately          = true
-  storage_encrypted          = true
-  kms_key_id                 = var.kms_key
-  allocated_storage          = var.allocated_storage
-  storage_type               = var.storage_type
-  storage_throughput         = var.storage_throughput
-  iops                       = var.storage_iops
-  engine                     = "postgres"
-  engine_version             = var.engine_version
-  instance_class             = var.instance_class
-  username                   = var.username
-  password                   = var.password
-  backup_retention_period    = var.backup_retention_period
-  db_subnet_group_name       = var.subnet_group
-  auto_minor_version_upgrade = var.auto_minor_version_upgrade
-  maintenance_window         = var.maintenance_window
-  deletion_protection        = var.deletion_protection
-  multi_az                   = var.multi_az
-  copy_tags_to_snapshot      = var.copy_tags_to_snapshot
-  option_group_name          = aws_db_option_group.this.name
-  parameter_group_name       = aws_db_parameter_group.this.name
-  skip_final_snapshot        = true
+  identifier                  = var.identifier
+  db_name                     = var.name
+  publicly_accessible         = false
+  apply_immediately           = true
+  storage_encrypted           = true
+  kms_key_id                  = var.kms_key
+  allocated_storage           = var.allocated_storage
+  storage_type                = var.storage_type
+  storage_throughput          = var.storage_throughput
+  iops                        = var.storage_iops
+  engine                      = "postgres"
+  engine_version              = var.engine_version
+  instance_class              = var.instance_class
+  username                    = var.username
+  password                    = var.password
+  backup_retention_period     = var.backup_retention_period
+  db_subnet_group_name        = var.subnet_group
+  auto_minor_version_upgrade  = var.auto_minor_version_upgrade
+  allow_major_version_upgrade = var.allow_major_version_upgrade
+  maintenance_window          = var.maintenance_window
+  deletion_protection         = var.deletion_protection
+  multi_az                    = var.multi_az
+  copy_tags_to_snapshot       = var.copy_tags_to_snapshot
+  option_group_name           = aws_db_option_group.this.name
+  parameter_group_name        = aws_db_parameter_group.this.name
+  skip_final_snapshot         = true
 
   performance_insights_enabled    = var.performance_insights
   enabled_cloudwatch_logs_exports = var.cloudwatch_log_exports

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -79,6 +79,11 @@ variable "auto_minor_version_upgrade" {
   default = true
 }
 
+variable "allow_major_version_upgrade" {
+  type    = bool
+  default = false
+}
+
 variable "deletion_protection" {
   default = false
 }


### PR DESCRIPTION
Currently getting the following error when trying to upgrade the dev database from nerves_hub_infrastructure.
```
Error: updating RDS DB Instance (nerves-hub-web-dev): operation error RDS: ModifyDBInstance, https
response error StatusCode: 400, RequestID: 891a19dc-9276-4d00-bedd-89a3acc1ec9c, api error
InvalidParameterCombination: The AllowMajorVersionUpgrade flag must be present when upgrading to
a new major version.
```