### PR TITLE
TECH: Allow overriding DB pool size for device tasks

### DIFF
--- a/modules/device/README.md
+++ b/modules/device/README.md
@@ -26,9 +26,12 @@
 | Name | Type |
 |------|------|
 | [aws_ecs_service.device_ecs_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.device_exec_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
 | [aws_ecs_task_definition.device_task_definition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_iam_policy.device_exec_task_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.device_task_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.device_task_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.device_exec_role_policy_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.device_role_policy_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lb.device_lb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_lb_listener.device_lb_listener](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
@@ -41,6 +44,7 @@
 | [aws_ssm_parameter.nerves_hub_device_ssm_s3_bucket_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.nerves_hub_device_ssm_s3_log_bucket_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.nerves_hub_device_ssm_s3_ssl_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.nerves_hub_device_ssm_secret_db_pool_size](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.nerves_hub_device_ssm_secret_db_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.nerves_hub_device_ssm_secret_erl_cookie](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.nerves_hub_device_ssm_secret_secret_key_base](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
@@ -50,6 +54,7 @@
 | [aws_ssm_parameter.nerves_hub_device_ssm_smtp_username](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.nerves_hub_www_ses_from_email](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [random_integer.target_group_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
+| [aws_iam_policy_document.device_exec_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.device_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
@@ -67,6 +72,7 @@
 | <a name="input_datadog_image"></a> [datadog\_image](#input\_datadog\_image) | Datadog container image | `string` | n/a | yes |
 | <a name="input_datadog_key_arn"></a> [datadog\_key\_arn](#input\_datadog\_key\_arn) | Datadog Key | `string` | n/a | yes |
 | <a name="input_db"></a> [db](#input\_db) | n/a | `any` | n/a | yes |
+| <a name="input_device_db_pool_size"></a> [device\_db\_pool\_size](#input\_device\_db\_pool\_size) | Database Pool Size for Device Tasks | `number` | `5` | no |
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | n/a | `any` | n/a | yes |
 | <a name="input_docker_image_tag"></a> [docker\_image\_tag](#input\_docker\_image\_tag) | Docker Image tag for Device Application | `string` | n/a | yes |
 | <a name="input_erl_cookie"></a> [erl\_cookie](#input\_erl\_cookie) | n/a | `any` | n/a | yes |

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -71,6 +71,14 @@ resource "aws_ssm_parameter" "nerves_hub_device_ssm_secret_db_url" {
   tags      = var.tags
 }
 
+resource "aws_ssm_parameter" "nerves_hub_device_ssm_secret_db_pool_size" {
+  name      = "/${local.device_app_name}/${terraform.workspace}/POOL_SIZE"
+  type      = "String"
+  value     = var.device_db_pool_size
+  overwrite = true
+  tags      = var.tags
+}
+
 resource "aws_ssm_parameter" "nerves_hub_device_ssm_secret_erl_cookie" {
   name      = "/${local.device_app_name}/${terraform.workspace}/ERL_COOKIE"
   type      = "SecureString"
@@ -350,10 +358,10 @@ data "aws_iam_policy_document" "device_exec_iam_policy" {
   statement {
     sid = "execssm"
     actions = [
-         "ssmmessages:OpenDataChannel",
-         "ssmmessages:OpenControlChannel",
-         "ssmmessages:CreateDataChannel",
-         "ssmmessages:CreateControlChannel"
+      "ssmmessages:OpenDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:CreateControlChannel"
     ]
     resources = [
       "*"
@@ -361,14 +369,14 @@ data "aws_iam_policy_document" "device_exec_iam_policy" {
     effect = "Allow"
   }
   statement {
-    sid = "execcmd"
+    sid     = "execcmd"
     actions = ["ecs:ExecuteCommand"]
     resources = [
       aws_ecs_service.device_ecs_service.cluster,
       "arn:aws:ecs:${var.region}:${var.account_id}:task-definition/nerves-hub-${terraform.workspace}-device-exec:*",
     ]
     effect = "Allow"
-}
+  }
 }
 
 resource "aws_iam_policy" "device_task_policy" {

--- a/modules/device/variables.tf
+++ b/modules/device/variables.tf
@@ -66,3 +66,9 @@ variable "datadog_key_arn" {
   description = "Datadog Key"
   type        = string
 }
+
+variable "device_db_pool_size" {
+  description = "Database Pool Size for Device Tasks"
+  type        = number
+  default     = 5
+}


### PR DESCRIPTION
This will allow us to more easily adjust the pool size to handle spikes in reconnections.