### PR TITLE
TECH: increase nerves-hub ecs ulimits

### DIFF
--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -438,7 +438,7 @@ resource "aws_ecs_task_definition" "api_task_definition" {
          {
           "name": "nofile",
           "hardLimit": 51200,
-          "softLimit": 51200,
+          "softLimit": 51200
          }
        ],
        "networkMode": "awsvpc",

--- a/modules/api/main.tf
+++ b/modules/api/main.tf
@@ -434,6 +434,13 @@ resource "aws_ecs_task_definition" "api_task_definition" {
            "containerPort": 4369
          }
        ],
+      "ulimits": [
+         {
+          "name": "nofile",
+          "hardLimit": 51200,
+          "softLimit": 51200,
+         }
+       ],
        "networkMode": "awsvpc",
        "image": "${var.docker_image}",
        "essential": true,

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -428,6 +428,13 @@ resource "aws_ecs_task_definition" "device_task_definition" {
            "containerPort": 4369
          }
        ],
+       "ulimits": [
+         {
+          "name": "nofile",
+          "hardLimit": 51200,
+          "softLimit": 51200,
+         }
+       ],
        "networkMode": "awsvpc",
        "image": "${var.docker_image}",
        "essential": true,

--- a/modules/device/main.tf
+++ b/modules/device/main.tf
@@ -432,7 +432,7 @@ resource "aws_ecs_task_definition" "device_task_definition" {
          {
           "name": "nofile",
           "hardLimit": 51200,
-          "softLimit": 51200,
+          "softLimit": 51200
          }
        ],
        "networkMode": "awsvpc",

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -450,6 +450,13 @@ resource "aws_ecs_task_definition" "www_task_definition" {
            "containerPort": 4369
          }
        ],
+       "ulimits": [
+         {
+          "name": "nofile",
+          "hardLimit": 51200,
+          "softLimit": 51200,
+         }
+       ],
        "networkMode": "awsvpc",
        "image": "${var.docker_image}",
        "essential": true,

--- a/modules/www/main.tf
+++ b/modules/www/main.tf
@@ -454,7 +454,7 @@ resource "aws_ecs_task_definition" "www_task_definition" {
          {
           "name": "nofile",
           "hardLimit": 51200,
-          "softLimit": 51200,
+          "softLimit": 51200
          }
        ],
        "networkMode": "awsvpc",


### PR DESCRIPTION
I read online that you shouldnt increase ecs task ulimits to no more than 1/10th of their allocated memory in kilobytes here: https://stackoverflow.com/questions/37209834/how-do-i-configure-ulimits-for-a-docker-container-running-in-aws-ecs
this seemed appropriate for what we were using in zipato as well. 