### PR TITLE
Expose API load balancer security group ids so we can reference them

### DIFF
--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -111,7 +111,9 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_alb_dns_name"></a> [alb\_dns\_name](#output\_alb\_dns\_name) | n/a |
+| <a name="output_alb_security_group_id"></a> [alb\_security\_group\_id](#output\_alb\_security\_group\_id) | n/a |
 | <a name="output_alb_zone_id"></a> [alb\_zone\_id](#output\_alb\_zone\_id) | n/a |
 | <a name="output_lb_dns_name"></a> [lb\_dns\_name](#output\_lb\_dns\_name) | n/a |
 | <a name="output_lb_zone_id"></a> [lb\_zone\_id](#output\_lb\_zone\_id) | n/a |
+| <a name="output_nlb_security_group_id"></a> [nlb\_security\_group\_id](#output\_nlb\_security\_group\_id) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/api/output.tf
+++ b/modules/api/output.tf
@@ -13,3 +13,11 @@ output "alb_zone_id" {
 output "alb_dns_name" {
   value = var.alb ? element(aws_lb.api_alb.*.dns_name, 0) : null
 }
+
+output "alb_security_group_id" {
+  value = aws_security_group.port80_lb_security_group.id
+}
+
+output "nlb_security_group_id" {
+  value = aws_security_group.port443_lb_security_group.id
+}


### PR DESCRIPTION
Should make it so we can actually allow traffic to make it to the API tasks on port 80.