### PR TITLE
TECH: Prevent conflicts when target groups changes from port 443 to 80

### DIFF
--- a/modules/api/README.md
+++ b/modules/api/README.md
@@ -39,7 +39,7 @@
 | [aws_lb_listener.api_lb_listener](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.http_alb_listener](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.https_alb_listener](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
-| [aws_lb_target_group.api_alb_tg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group.api_alb_tg_80](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_lb_target_group.api_lb_tg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_security_group.port443_lb_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.port80_lb_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |

--- a/modules/api/alb.tf
+++ b/modules/api/alb.tf
@@ -1,5 +1,5 @@
 # Load Balancer
-resource "aws_lb_target_group" "api_alb_tg" {
+resource "aws_lb_target_group" "api_alb_tg_80" {
   count                = var.alb ? 1 : 0
   name                 = "nerves-hub-${terraform.workspace}-api-tg-80"
   port                 = 80
@@ -69,7 +69,7 @@ resource "aws_lb_listener" "https_alb_listener" {
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.api_alb_tg[count.index].arn
+    target_group_arn = aws_lb_target_group.api_alb_tg_80[count.index].arn
   }
 }
 
@@ -162,7 +162,7 @@ resource "aws_ecs_service" "api_public_ecs_service" {
   health_check_grace_period_seconds = 300
 
   load_balancer {
-    target_group_arn = aws_lb_target_group.api_alb_tg[count.index].arn
+    target_group_arn = aws_lb_target_group.api_alb_tg_80[count.index].arn
     container_name   = local.app_name
     container_port   = 80
   }


### PR DESCRIPTION
This should make it destroy the old one and create a new one so it stops trying to update the existing on in place which makes everything more difficult.